### PR TITLE
Fix for Spark < 1.6

### DIFF
--- a/src/main/java/org/datasyslab/geospark/spatialRDD/SpatialRDD.java
+++ b/src/main/java/org/datasyslab/geospark/spatialRDD/SpatialRDD.java
@@ -83,7 +83,7 @@ public abstract class SpatialRDD implements Serializable{
 	 */
 	public boolean spatialPartitioning(GridType gridType) throws Exception
 	{
-        int numPartitions = this.rawSpatialRDD.getNumPartitions();
+        int numPartitions = this.rawSpatialRDD.rdd().partitions().length;
 		if(this.boundaryEnvelope==null)
         {
         	throw new Exception("[AbstractSpatialRDD][spatialPartitioning] SpatialRDD boundary is null. Please call boundary() first.");


### PR DESCRIPTION
This one line PR fixes a crash when doing spatial partitioning in Spark versions < 1.6.

The fix is to use JavaRDD.rdd().partitions().length rather than JavaRDD.getNumPartitions() for Spark <1.6 compatibility.  This safely gets the number of partitions for this RDD for all versions of Spark 1.X.  (1.0.0 through 1.6.X).  

Note JavaRDDLike has a partitions() method but it is not available in Spark 1.0.0 so I used this approach.

Request: when releasing a new version for 1.X could you please tag the branch with a tag?  It seems only the mainline releases get tags on master.  Thanks...
