### PR TITLE
Make SpatialRDD a generic class parameterized over geometry type

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
 	<artifactId>geospark</artifactId>
-	<version>0.8.1</version>
+	<version>0.8.1-SNAPSHOT</version>
 	
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Geospatial extension for Apache Spark</description>
@@ -89,6 +89,16 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
             <artifactId>gt-referencing</artifactId>
             <version>${geotools.version}</version>
         </dependency>
@@ -138,7 +148,36 @@
             <version>2.4.16</version>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-metadata</artifactId>
+            <version>${geotools.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-data</artifactId>
+            <version>${geotools.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jscience</groupId>
+            <artifactId>jscience</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.efficient-java-matrix-library</groupId>
+            <artifactId>core</artifactId>
+            <version>0.26</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+    </dependencies>
     <repositories>
       <repository>
           <id>maven2-repository.dev.java.net</id>

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/LineStringFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/LineStringFormatMapper.java
@@ -6,31 +6,26 @@
  */
 package org.datasyslab.geospark.formatMapper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.io.WKTReader;
 import org.apache.spark.api.java.function.FlatMapFunction;
-
 import org.datasyslab.geospark.enums.FileDataSplitter;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.GeoJSONFactory;
 import org.wololo.jts2geojson.GeoJSONReader;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.WKTReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class LineStringFormatMapper.
  */
-public class LineStringFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Object> {
+public class LineStringFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, LineString> {
 	
 	/**
 	 * Instantiates a new line string format mapper.
@@ -59,7 +54,7 @@ public class LineStringFormatMapper extends FormatMapper implements FlatMapFunct
 
 
     @Override
-    public Iterator<Object> call(Iterator<String> stringIterator) throws Exception {
+    public Iterator<LineString> call(Iterator<String> stringIterator) throws Exception {
         List result= new ArrayList<LineString>();
         MultiLineString multiSpatialObjects = null;
         int actualEndOffset;

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/PointFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/PointFormatMapper.java
@@ -6,28 +6,26 @@
  */
 package org.datasyslab.geospark.formatMapper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.io.WKTReader;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.datasyslab.geospark.enums.FileDataSplitter;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.GeoJSONFactory;
 import org.wololo.jts2geojson.GeoJSONReader;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.WKTReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class PointFormatMapper.
  */
-public class PointFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Object> {
+public class PointFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Point> {
 
 
 	/**
@@ -56,7 +54,7 @@ public class PointFormatMapper extends FormatMapper implements FlatMapFunction<I
 	}
 
     @Override
-    public Iterator<Object> call(Iterator<String> stringIterator) throws Exception {
+    public Iterator<Point> call(Iterator<String> stringIterator) throws Exception {
         MultiPoint multiSpatialObjects = null;
         Coordinate coordinate;
         List result= new ArrayList<Point>();

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/PolygonFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/PolygonFormatMapper.java
@@ -6,31 +6,27 @@
  */
 package org.datasyslab.geospark.formatMapper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTReader;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.datasyslab.geospark.enums.FileDataSplitter;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.GeoJSONFactory;
 import org.wololo.jts2geojson.GeoJSONReader;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.io.WKTReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class PolygonFormatMapper.
  */
-public class PolygonFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Object> {
+public class PolygonFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Polygon> {
  
 	
     /**
@@ -59,7 +55,7 @@ public class PolygonFormatMapper extends FormatMapper implements FlatMapFunction
 	}
 
     @Override
-    public Iterator<Object> call(Iterator<String> stringIterator) throws Exception {
+    public Iterator<Polygon> call(Iterator<String> stringIterator) throws Exception {
         MultiPolygon multiSpatialObjects = null;
         LinearRing linear;
         int actualEndOffset;

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/RectangleFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/RectangleFormatMapper.java
@@ -6,30 +6,27 @@
  */
 package org.datasyslab.geospark.formatMapper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTReader;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.datasyslab.geospark.enums.FileDataSplitter;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.GeoJSONFactory;
 import org.wololo.jts2geojson.GeoJSONReader;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.io.WKTReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class RectangleFormatMapper.
  */
-public class RectangleFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Object>
+public class RectangleFormatMapper extends FormatMapper implements FlatMapFunction<Iterator<String>, Polygon>
 {
 
 	/**
@@ -56,7 +53,7 @@ public class RectangleFormatMapper extends FormatMapper implements FlatMapFuncti
 	}
 
 	@Override
-	public Iterator<Object> call(Iterator<String> stringIterator) throws Exception {
+	public Iterator<Polygon> call(Iterator<String> stringIterator) throws Exception {
 		MultiPolygon multiSpatialObjects = null;
 		List result= new ArrayList<Polygon>();
 		Double x1,x2,y1,y2;

--- a/core/src/main/java/org/datasyslab/geospark/knnJudgement/KnnJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/knnJudgement/KnnJudgement.java
@@ -7,15 +7,14 @@
 package org.datasyslab.geospark.knnJudgement;
 
 
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import org.apache.spark.api.java.function.FlatMapFunction;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.PriorityQueue;
-
-import org.apache.spark.api.java.function.FlatMapFunction;
-
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Point;
 
 
 
@@ -23,7 +22,7 @@ import com.vividsolutions.jts.geom.Point;
 /**
  * The Class GeometryKnnJudgement.
  */
-public class KnnJudgement implements FlatMapFunction<Iterator<Object>, Object>, Serializable{
+public class KnnJudgement<T extends Geometry> implements FlatMapFunction<Iterator<T>, Object>, Serializable{
 	
 	/** The k. */
 	int k;
@@ -47,13 +46,13 @@ public class KnnJudgement implements FlatMapFunction<Iterator<Object>, Object>, 
 	 * @see org.apache.spark.api.java.function.FlatMapFunction#call(java.lang.Object)
 	 */
 	@Override
-	public Iterator<Object> call(Iterator<Object> input) throws Exception {		
+	public Iterator<Object> call(Iterator<T> input) throws Exception {
 		PriorityQueue<Object> pq = new PriorityQueue<Object>(k, new GeometryDistanceComparator(queryCenter,false));
 		while (input.hasNext()) {
 			if (pq.size() < k) {
 				pq.offer(input.next());
 			} else {
-				Geometry curpoint = (Geometry)input.next();
+				Geometry curpoint = input.next();
 				double distance = curpoint.distance(queryCenter);
 				double largestDistanceInPriQueue = ((Geometry) pq.peek()).distance(queryCenter);
 				if (largestDistanceInPriQueue > distance) {

--- a/core/src/main/java/org/datasyslab/geospark/knnJudgement/KnnJudgementUsingIndex.java
+++ b/core/src/main/java/org/datasyslab/geospark/knnJudgement/KnnJudgementUsingIndex.java
@@ -6,25 +6,22 @@
  */
 package org.datasyslab.geospark.knnJudgement;
 
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.index.SpatialIndex;
+import com.vividsolutions.jts.index.strtree.GeometryItemDistance;
+import com.vividsolutions.jts.index.strtree.STRtree;
+import org.apache.spark.api.java.function.FlatMapFunction;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.spark.api.java.function.FlatMapFunction;
-
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.index.SpatialIndex;
-import com.vividsolutions.jts.index.strtree.GeometryItemDistance;
-import com.vividsolutions.jts.index.strtree.STRtree;
-
 // TODO: Auto-generated Javadoc
 /**
  * The Class KnnJudgementUsingIndex.
  */
-public class KnnJudgementUsingIndex implements FlatMapFunction<Iterator<Object>, Object>, Serializable{
+public class KnnJudgementUsingIndex implements FlatMapFunction<Iterator<SpatialIndex>, Object>, Serializable{
 	
 	/** The k. */
 	int k;
@@ -48,11 +45,9 @@ public class KnnJudgementUsingIndex implements FlatMapFunction<Iterator<Object>,
 	 * @see org.apache.spark.api.java.function.FlatMapFunction#call(java.lang.Object)
 	 */
 	@Override
-	public Iterator<Object> call(Iterator<Object> treeIndexes) throws Exception {
-		// TODO Auto-generated method stub
-		GeometryFactory fact= new GeometryFactory();
-		Object treeIndex = treeIndexes.next();
-		Object[] localK=null;
+	public Iterator<Object> call(Iterator<SpatialIndex> treeIndexes) throws Exception {
+		SpatialIndex treeIndex = treeIndexes.next();
+		final Object[] localK;
 		if(treeIndex instanceof STRtree)
 		{
 			localK = ((STRtree)treeIndex).kNearestNeighbour(queryCenter.getEnvelopeInternal(), queryCenter, new GeometryItemDistance(), k);

--- a/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilter.java
+++ b/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilter.java
@@ -6,19 +6,18 @@
  */
 package org.datasyslab.geospark.rangeJudgement;
 
-import java.io.Serializable;
-
-import org.apache.spark.api.java.function.Function;
-
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
+import org.apache.spark.api.java.function.Function;
+
+import java.io.Serializable;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class GeometryRangeFilter.
  */
-public class RangeFilter implements Function<Object,Boolean>,Serializable {
+public class RangeFilter<T extends Geometry> implements Function<T, Boolean>,Serializable {
 	
 	/** The condition. */
 	boolean considerBoundaryIntersection=false;
@@ -53,43 +52,27 @@ public class RangeFilter implements Function<Object,Boolean>,Serializable {
 	/* (non-Javadoc)
 	 * @see org.apache.spark.api.java.function.Function#call(java.lang.Object)
 	 */
-	public Boolean call(Object tuple) throws Exception {
+	public Boolean call(T geometry) throws Exception {
 			if(considerBoundaryIntersection==false)
 			{
 				if(queryWindow instanceof Envelope)
 				{
-					if(((Envelope)queryWindow).contains(((Geometry) tuple).getEnvelopeInternal()))
-					{
-						return true;
-					}
-					else return false;
+					return (((Envelope)queryWindow).contains(geometry.getEnvelopeInternal()));
 				}
 				else
 				{
-					if(((Polygon)queryWindow).contains((Geometry) tuple))
-					{
-						return true;
-					}
-					else return false;
+					return (((Polygon)queryWindow).contains(geometry));
 				}
 			}
 			else
 			{
 				if(queryWindow instanceof Envelope)
 				{
-					if(((Envelope)queryWindow).intersects(((Geometry) tuple).getEnvelopeInternal()))
-					{
-						return true;
-					}
-					else return false;
+					return (((Envelope)queryWindow).intersects(geometry.getEnvelopeInternal()));
 				}
 				else
 				{
-					if(((Polygon)queryWindow).intersects((Geometry) tuple))
-					{
-						return true;
-					}
-					else return false;
+					return (((Polygon)queryWindow).intersects(geometry));
 				}
 			}
 	}

--- a/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilterUsingIndex.java
+++ b/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilterUsingIndex.java
@@ -6,25 +6,24 @@
  */
 package org.datasyslab.geospark.rangeJudgement;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import org.apache.spark.api.java.function.FlatMapFunction;
-
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.quadtree.Quadtree;
 import com.vividsolutions.jts.index.strtree.STRtree;
+import org.apache.spark.api.java.function.FlatMapFunction;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class RangeFilterUsingIndex.
  */
-public class RangeFilterUsingIndex implements FlatMapFunction<Iterator<Object>,Object>, Serializable{
+public class RangeFilterUsingIndex implements FlatMapFunction<Iterator<SpatialIndex>, Object>, Serializable{
 
 	/** The consider boundary intersection. */
 	boolean considerBoundaryIntersection=false;
@@ -69,9 +68,9 @@ public class RangeFilterUsingIndex implements FlatMapFunction<Iterator<Object>,O
 	 * @see org.apache.spark.api.java.function.FlatMapFunction#call(java.lang.Object)
 	 */
 	@Override
-	public Iterator<Object> call(Iterator<Object> treeIndexes) throws Exception {
+	public Iterator<Object> call(Iterator<SpatialIndex> treeIndexes) throws Exception {
 		assert treeIndexes.hasNext()==true;
-		Object treeIndex = treeIndexes.next();
+		SpatialIndex treeIndex = treeIndexes.next();
 		if(treeIndex instanceof STRtree)
 		{
 			STRtree strtree= (STRtree) treeIndex;
@@ -97,8 +96,7 @@ public class RangeFilterUsingIndex implements FlatMapFunction<Iterator<Object>,O
 			}
 			else
 			{
-				List tempResult=new ArrayList();
-				tempResult=strtree.query(((Polygon)this.queryWindow).getEnvelopeInternal());
+				List tempResult = strtree.query(((Polygon)this.queryWindow).getEnvelopeInternal());
 				for(Object spatialObject:tempResult)
 				{
 					if(considerBoundaryIntersection)

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/CircleRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/CircleRDD.java
@@ -20,7 +20,7 @@ import com.vividsolutions.jts.geom.Polygon;
 /**
  * The Class CircleRDD.
  */
-public class CircleRDD extends SpatialRDD {
+public class CircleRDD extends SpatialRDD<Circle> {
 
 
 	/**
@@ -29,14 +29,7 @@ public class CircleRDD extends SpatialRDD {
 	 * @param circleRDD the circle RDD
 	 */
 	public CircleRDD(JavaRDD<Circle> circleRDD) {
-		this.rawSpatialRDD = circleRDD.map(new Function<Circle,Object>()
-		{
-
-			@Override
-			public Object call(Circle circle) throws Exception {
-				return circle;
-			}
-		});
+		this.rawSpatialRDD = circleRDD;
 	}
 
 	/**
@@ -47,14 +40,7 @@ public class CircleRDD extends SpatialRDD {
 	 * @param targetEpsgCRSCode the target epsg CRS code
 	 */
 	public CircleRDD(JavaRDD<Circle> circleRDD, String sourceEpsgCRSCode, String targetEpsgCRSCode) {
-		this.rawSpatialRDD = circleRDD.map(new Function<Circle,Object>()
-		{
-
-			@Override
-			public Object call(Circle circle) throws Exception {
-				return circle;
-			}
-		});
+		this.rawSpatialRDD = circleRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCRSCode);
 	}
 	
@@ -85,11 +71,10 @@ public class CircleRDD extends SpatialRDD {
 	 * @return the center point as spatial RDD
 	 */
 	public PointRDD getCenterPointAsSpatialRDD() {
-		return new PointRDD(this.rawSpatialRDD.map(new Function<Object, Point>() {
+		return new PointRDD(this.rawSpatialRDD.map(new Function<Circle, Point>() {
 
-			public Point call(Object spatialObject) {
-
-				return (Point)((Circle)spatialObject).getCenterGeometry();
+			public Point call(Circle circle) {
+				return (Point)circle.getCenterGeometry();
 			}
 		}));
 
@@ -101,11 +86,11 @@ public class CircleRDD extends SpatialRDD {
 	 * @return the center polygon as spatial RDD
 	 */
 	public PolygonRDD getCenterPolygonAsSpatialRDD() {
-		return new PolygonRDD(this.rawSpatialRDD.map(new Function<Object, Polygon>() {
+		return new PolygonRDD(this.rawSpatialRDD.map(new Function<Circle, Polygon>() {
 
-			public Polygon call(Object spatialObject) {
+			public Polygon call(Circle circle) {
 
-				return (Polygon)((Circle)spatialObject).getCenterGeometry();
+				return (Polygon)circle.getCenterGeometry();
 			}
 		}));
 	}
@@ -116,11 +101,11 @@ public class CircleRDD extends SpatialRDD {
 	 * @return the center line string RDD as spatial RDD
 	 */
 	public LineStringRDD getCenterLineStringRDDAsSpatialRDD() {
-		return new LineStringRDD(this.rawSpatialRDD.map(new Function<Object, LineString>() {
+		return new LineStringRDD(this.rawSpatialRDD.map(new Function<Circle, LineString>() {
 
-			public LineString call(Object spatialObject) {
+			public LineString call(Circle circle) {
 
-				return (LineString)((Circle)spatialObject).getCenterGeometry();
+				return (LineString) circle.getCenterGeometry();
 			}
 		}));
 	}
@@ -131,11 +116,11 @@ public class CircleRDD extends SpatialRDD {
 	 * @return the center rectangle RDD as spatial RDD
 	 */
 	public RectangleRDD getCenterRectangleRDDAsSpatialRDD() {
-		return new RectangleRDD(this.rawSpatialRDD.map(new Function<Object, Polygon>() {
+		return new RectangleRDD(this.rawSpatialRDD.map(new Function<Circle, Polygon>() {
 
-			public Polygon call(Object spatialObject) {
+			public Polygon call(Circle circle) {
 
-				return (Polygon)((Circle)spatialObject).getCenterGeometry();
+				return (Polygon) circle.getCenterGeometry();
 			}
 		}));
 	}

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/LineStringRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/LineStringRDD.java
@@ -7,21 +7,19 @@
 package org.datasyslab.geospark.spatialRDD;
 
 import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.LineString;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.storage.StorageLevel;
 import org.datasyslab.geospark.enums.FileDataSplitter;
 import org.datasyslab.geospark.formatMapper.LineStringFormatMapper;
-
-import com.vividsolutions.jts.geom.LineString;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class LineStringRDD.
  */
-public class LineStringRDD extends SpatialRDD{
+public class LineStringRDD extends SpatialRDD<LineString> {
 	
 	/**
 	 * Instantiates a new line string RDD.
@@ -29,13 +27,7 @@ public class LineStringRDD extends SpatialRDD{
 	 * @param rawSpatialRDD the raw spatial RDD
 	 */
 	public LineStringRDD(JavaRDD<LineString> rawSpatialRDD) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-        {
-            @Override
-            public Object call(LineString spatialObject) throws Exception {
-                return spatialObject;
-            }
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
     }
 	
 	/**
@@ -46,14 +38,7 @@ public class LineStringRDD extends SpatialRDD{
 	 * @param targetEpsgCode the target epsg code
 	 */
 	public LineStringRDD(JavaRDD<LineString> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-		{
-			@Override
-			public Object call(LineString spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
     }
 
@@ -146,13 +131,7 @@ public class LineStringRDD extends SpatialRDD{
      * @param approximateTotalCount the approximate total count
      */
     public LineStringRDD(JavaRDD<LineString> rawSpatialRDD, Envelope datasetBoundary, Integer approximateTotalCount) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-        {
-            @Override
-            public Object call(LineString spatialObject) throws Exception {
-                return spatialObject;
-            }
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
     }
@@ -167,14 +146,7 @@ public class LineStringRDD extends SpatialRDD{
      * @param approximateTotalCount the approximate total count
      */
     public LineStringRDD(JavaRDD<LineString> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode, Envelope datasetBoundary, Integer approximateTotalCount) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-        {
-            @Override
-            public Object call(LineString spatialObject) throws Exception {
-                return spatialObject;
-            }
-
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
@@ -293,14 +265,7 @@ public class LineStringRDD extends SpatialRDD{
 	 * @param newLevel the new level
 	 */
 	public LineStringRDD(JavaRDD<LineString> rawSpatialRDD, StorageLevel newLevel) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-		{
-			@Override
-			public Object call(LineString spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.analyze(newLevel);
     }
 
@@ -410,14 +375,7 @@ public class LineStringRDD extends SpatialRDD{
 	 * @param targetEpsgCode the target epsg code
 	 */
 	public LineStringRDD(JavaRDD<LineString> rawSpatialRDD, StorageLevel newLevel, String sourceEpsgCRSCode, String targetEpsgCode) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<LineString,Object>()
-		{
-			@Override
-			public Object call(LineString spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
 		this.analyze(newLevel);
     }

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/PointRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/PointRDD.java
@@ -6,25 +6,14 @@
  */
 package org.datasyslab.geospark.spatialRDD;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-
-
 import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Point;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.storage.StorageLevel;
 import org.datasyslab.geospark.enums.FileDataSplitter;
-
 import org.datasyslab.geospark.formatMapper.PointFormatMapper;
-
-import org.wololo.geojson.GeoJSON;
-import org.wololo.jts2geojson.GeoJSONWriter;
-
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Point;
 
 
 // TODO: Auto-generated Javadoc
@@ -32,7 +21,7 @@ import com.vividsolutions.jts.geom.Point;
  * The Class PointRDD.
  */
 
-public class PointRDD extends SpatialRDD {
+public class PointRDD extends SpatialRDD<Point> {
     
 	/**
 	 * Instantiates a new point RDD.
@@ -41,14 +30,7 @@ public class PointRDD extends SpatialRDD {
 	 */
 	public PointRDD(JavaRDD<Point> rawSpatialRDD)
 	{
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-        {
-
-            @Override
-            public Object call(Point spatialObject) throws Exception {
-                return spatialObject;
-            }
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
 	}
 	
 	/**
@@ -60,14 +42,7 @@ public class PointRDD extends SpatialRDD {
 	 */
 	public PointRDD(JavaRDD<Point> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-		{
-
-			@Override
-			public Object call(Point spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
 	}
 	
@@ -160,14 +135,7 @@ public class PointRDD extends SpatialRDD {
      */
     public PointRDD(JavaRDD<Point> rawSpatialRDD, Envelope datasetBoundary, Integer approximateTotalCount)
     {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-        {
-
-            @Override
-            public Object call(Point spatialObject) throws Exception {
-                return spatialObject;
-            }
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
     }
@@ -183,15 +151,7 @@ public class PointRDD extends SpatialRDD {
      */
     public PointRDD(JavaRDD<Point> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode, Envelope datasetBoundary, Integer approximateTotalCount)
     {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-        {
-
-            @Override
-            public Object call(Point spatialObject) throws Exception {
-                return spatialObject;
-            }
-
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
@@ -297,11 +257,6 @@ public class PointRDD extends SpatialRDD {
         this.approximateTotalCount = approximateTotalCount;
     }
 
-
-
-
-
-
 	/**
 	 * Instantiates a new point RDD.
 	 *
@@ -310,15 +265,7 @@ public class PointRDD extends SpatialRDD {
 	 */
 	public PointRDD(JavaRDD<Point> rawSpatialRDD, StorageLevel newLevel)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-		{
-
-			@Override
-			public Object call(Point spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
         this.analyze(newLevel);
 	}
 	
@@ -419,14 +366,7 @@ public class PointRDD extends SpatialRDD {
 	 */
 	public PointRDD(JavaRDD<Point> rawSpatialRDD, StorageLevel newLevel, String sourceEpsgCRSCode, String targetEpsgCode)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Point,Object>()
-		{
-			@Override
-			public Object call(Point spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.analyze(newLevel);
 	}

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/PolygonRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/PolygonRDD.java
@@ -6,28 +6,6 @@
  */
 package org.datasyslab.geospark.spatialRDD;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.api.java.function.Function2;
-import org.apache.spark.storage.StorageLevel;
-import org.datasyslab.geospark.enums.FileDataSplitter;
-import org.datasyslab.geospark.formatMapper.PolygonFormatMapper;
-
-import org.wololo.geojson.GeoJSON;
-import org.wololo.jts2geojson.GeoJSONWriter;
-
-/**
- * 
- * @author Arizona State University DataSystems Lab
- *
- */
-
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
@@ -36,13 +14,27 @@ import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.geom.PrecisionModel;
 import com.vividsolutions.jts.precision.GeometryPrecisionReducer;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.storage.StorageLevel;
+import org.datasyslab.geospark.enums.FileDataSplitter;
+import org.datasyslab.geospark.formatMapper.PolygonFormatMapper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * @author Arizona State University DataSystems Lab
+ */
 
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class PolygonRDD.
  */
-public class PolygonRDD extends SpatialRDD {
+public class PolygonRDD extends SpatialRDD<Polygon> {
     
 
 
@@ -52,14 +44,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param rawSpatialRDD the raw spatial RDD
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-        {
-            @Override
-            public Object call(Polygon spatialObject) throws Exception {
-                return spatialObject;
-            }
-
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
     }
 
     /**
@@ -70,14 +55,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param targetEpsgCode the target epsg code
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
     }
 
@@ -172,14 +150,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param approximateTotalCount the approximate total count
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD, Envelope datasetBoundary, Integer approximateTotalCount) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-        {
-            @Override
-            public Object call(Polygon spatialObject) throws Exception {
-                return spatialObject;
-            }
-
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
     }
@@ -194,14 +165,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param approximateTotalCount the approximate total count
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode, Envelope datasetBoundary, Integer approximateTotalCount) {
-        this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-        {
-            @Override
-            public Object call(Polygon spatialObject) throws Exception {
-                return spatialObject;
-            }
-
-        });
+        this.rawSpatialRDD = rawSpatialRDD;
         this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.boundaryEnvelope = datasetBoundary;
         this.approximateTotalCount = approximateTotalCount;
@@ -320,14 +284,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param newLevel the new level
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD, StorageLevel newLevel) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
         this.analyze(newLevel);
     }
 
@@ -432,13 +389,13 @@ public class PolygonRDD extends SpatialRDD {
      * @return the polygon
      */
     public Polygon PolygonUnion() {
-    	Object result = this.rawSpatialRDD.reduce(new Function2<Object, Object, Object>() {
-            public Polygon call(Object v1, Object v2) {
+    	Polygon result = this.rawSpatialRDD.reduce(new Function2<Polygon, Polygon, Polygon>() {
+            public Polygon call(Polygon v1, Polygon v2) {
                 //Reduce precision in JTS to avoid TopologyException
                 PrecisionModel pModel = new PrecisionModel();
                 GeometryPrecisionReducer pReducer = new GeometryPrecisionReducer(pModel);
-                Geometry p1 = pReducer.reduce((Polygon) v1);
-                Geometry p2 = pReducer.reduce((Polygon) v2);
+                Geometry p1 = pReducer.reduce(v1);
+                Geometry p2 = pReducer.reduce(v2);
                 //Union two polygons
                 Geometry polygonGeom = p1.union(p2);
                 Coordinate[] coordinates = polygonGeom.getCoordinates();
@@ -454,7 +411,7 @@ public class PolygonRDD extends SpatialRDD {
                 return polygon;
             }
         });
-        return (Polygon)result;
+        return result;
     }
     
     /**
@@ -466,13 +423,7 @@ public class PolygonRDD extends SpatialRDD {
      * @param targetEpsgCode the target epsg code
      */
     public PolygonRDD(JavaRDD<Polygon> rawSpatialRDD, StorageLevel newLevel, String sourceEpsgCRSCode, String targetEpsgCode) {
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.analyze(newLevel);
     }

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/RectangleRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/RectangleRDD.java
@@ -6,25 +6,21 @@
  */
 package org.datasyslab.geospark.spatialRDD;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Polygon;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.storage.StorageLevel;
 import org.datasyslab.geospark.enums.FileDataSplitter;
-
 import org.datasyslab.geospark.formatMapper.RectangleFormatMapper;
-
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class RectangleRDD.
  */
 
-public class RectangleRDD extends SpatialRDD {
+public class RectangleRDD extends SpatialRDD<Polygon> {
 
     
     
@@ -35,14 +31,7 @@ public class RectangleRDD extends SpatialRDD {
 	 */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 	}
 	
 	/**
@@ -54,14 +43,7 @@ public class RectangleRDD extends SpatialRDD {
 	 */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
 	}
 	
@@ -157,14 +139,7 @@ public class RectangleRDD extends SpatialRDD {
 	 */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD, Envelope datasetBoundary, Integer approximateTotalCount)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.boundaryEnvelope = datasetBoundary;
 		this.approximateTotalCount = approximateTotalCount;
 	}
@@ -180,14 +155,7 @@ public class RectangleRDD extends SpatialRDD {
 	 */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD, String sourceEpsgCRSCode, String targetEpsgCode, Envelope datasetBoundary, Integer approximateTotalCount)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
 		this.boundaryEnvelope = datasetBoundary;
 		this.approximateTotalCount = approximateTotalCount;
@@ -307,15 +275,7 @@ public class RectangleRDD extends SpatialRDD {
      */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD, StorageLevel newLevel)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
         this.analyze(newLevel);
 
 	}
@@ -425,15 +385,7 @@ public class RectangleRDD extends SpatialRDD {
      */
 	public RectangleRDD(JavaRDD<Polygon> rawSpatialRDD, StorageLevel newLevel, String sourceEpsgCRSCode, String targetEpsgCode)
 	{
-		this.rawSpatialRDD = rawSpatialRDD.map(new Function<Polygon,Object>()
-		{
-
-			@Override
-			public Object call(Polygon spatialObject) throws Exception {
-				return spatialObject;
-			}
-			
-		});
+		this.rawSpatialRDD = rawSpatialRDD;
 		this.CRSTransform(sourceEpsgCRSCode, targetEpsgCode);
         this.analyze(newLevel);
 

--- a/core/src/main/java/org/datasyslab/geospark/utils/XMaxComparator.java
+++ b/core/src/main/java/org/datasyslab/geospark/utils/XMaxComparator.java
@@ -6,26 +6,29 @@
  */
 package org.datasyslab.geospark.utils;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+
 import java.io.Serializable;
 import java.util.Comparator;
-
-import com.vividsolutions.jts.geom.Geometry;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class XMaxComparator.
  */
-public class XMaxComparator implements Comparator<Object>, Serializable {
+public class XMaxComparator<T extends Geometry> implements Comparator<T>, Serializable {
 
 	 /* (non-Javadoc)
  	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
  	 */
- 	public int compare(Object spatialObject1, Object spatialObject2) {
- 		if(((Geometry) spatialObject1).getEnvelopeInternal().getMaxX()> ((Geometry) spatialObject2).getEnvelopeInternal().getMaxX())
+ 	public int compare(T spatialObject1, T spatialObject2) {
+		final Envelope envelope1 = spatialObject1.getEnvelopeInternal();
+		final Envelope envelope2 = spatialObject2.getEnvelopeInternal();
+ 		if(envelope1.getMaxX() > envelope2.getMaxX())
  		{
  			return 1;
  		}
- 		else if (((Geometry) spatialObject1).getEnvelopeInternal().getMaxX()<((Geometry) spatialObject2).getEnvelopeInternal().getMaxX())
+ 		else if (envelope1.getMaxX() < envelope2.getMaxX())
  		{
  			return -1;
  		}

--- a/core/src/main/java/org/datasyslab/geospark/utils/XMinComparator.java
+++ b/core/src/main/java/org/datasyslab/geospark/utils/XMinComparator.java
@@ -6,27 +6,29 @@
  */
 package org.datasyslab.geospark.utils;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+
 import java.io.Serializable;
 import java.util.Comparator;
-
-import com.vividsolutions.jts.geom.Geometry;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class XMinComparator.
  */
-public class XMinComparator implements Comparator<Object>, Serializable {
+public class XMinComparator<T extends Geometry> implements Comparator<T>, Serializable {
 
 	 /* (non-Javadoc)
  	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
  	 */
- 	public int compare(Object spatialObject1, Object spatialObject2) {
- 		
- 		if(((Geometry) spatialObject1).getEnvelopeInternal().getMinX()>((Geometry) spatialObject2).getEnvelopeInternal().getMinX())
+ 	public int compare(T spatialObject1, T spatialObject2) {
+		final Envelope envelope1 = spatialObject1.getEnvelopeInternal();
+		final Envelope envelope2 = spatialObject2.getEnvelopeInternal();
+		if(envelope1.getMinX() > envelope2.getMinX())
  		{
  			return 1;
  		}
- 		else if (((Geometry) spatialObject1).getEnvelopeInternal().getMinX()<((Geometry) spatialObject2).getEnvelopeInternal().getMinX())
+ 		else if (envelope1.getMinX() < envelope2.getMinX())
  		{
  			return -1;
  		}

--- a/core/src/main/java/org/datasyslab/geospark/utils/YMaxComparator.java
+++ b/core/src/main/java/org/datasyslab/geospark/utils/YMaxComparator.java
@@ -6,26 +6,29 @@
  */
 package org.datasyslab.geospark.utils;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+
 import java.io.Serializable;
 import java.util.Comparator;
-
-import com.vividsolutions.jts.geom.Geometry;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class YMaxComparator.
  */
-public class YMaxComparator implements Comparator<Object>, Serializable {
+public class YMaxComparator<T extends Geometry> implements Comparator<T>, Serializable {
 
 	 /* (non-Javadoc)
  	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
  	 */
- 	public int compare(Object spatialObject1, Object spatialObject2) {
- 		if(((Geometry) spatialObject1).getEnvelopeInternal().getMaxY()>((Geometry) spatialObject2).getEnvelopeInternal().getMaxY())
+ 	public int compare(T spatialObject1, T spatialObject2) {
+		final Envelope envelope1 = spatialObject1.getEnvelopeInternal();
+		final Envelope envelope2 = spatialObject2.getEnvelopeInternal();
+ 		if(envelope1.getMaxY() > envelope2.getMaxY())
  		{
  			return 1;
  		}
- 		else if (((Geometry) spatialObject1).getEnvelopeInternal().getMaxY()<((Geometry) spatialObject2).getEnvelopeInternal().getMaxY())
+ 		else if (envelope1.getMaxY() < envelope2.getMaxY())
  		{
  			return -1;
  		}

--- a/core/src/main/java/org/datasyslab/geospark/utils/YMinComparator.java
+++ b/core/src/main/java/org/datasyslab/geospark/utils/YMinComparator.java
@@ -6,26 +6,30 @@
  */
 package org.datasyslab.geospark.utils;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+
 import java.io.Serializable;
 import java.util.Comparator;
-
-import com.vividsolutions.jts.geom.Geometry;
 
 // TODO: Auto-generated Javadoc
 /**
  * The Class YMinComparator.
  */
-public class YMinComparator implements Comparator<Object>, Serializable {
+public class YMinComparator<T extends Geometry> implements Comparator<T>, Serializable {
 
 	 /* (non-Javadoc)
  	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
  	 */
- 	public int compare(Object spatialObject1, Object spatialObject2) {
- 		    if(((Geometry) spatialObject1).getEnvelopeInternal().getMinY()>((Geometry) spatialObject2).getEnvelopeInternal().getMinY())
+ 	public int compare(T spatialObject1, T spatialObject2) {
+		final Envelope envelope1 = spatialObject1.getEnvelopeInternal();
+		final Envelope envelope2 = spatialObject2.getEnvelopeInternal();
+
+ 		    if(envelope1.getMinY() > envelope2.getMinY())
  		    {
  		    	return 1;
  		    }
- 		    else if (((Geometry) spatialObject1).getEnvelopeInternal().getMinY()<((Geometry) spatialObject2).getEnvelopeInternal().getMinY())
+ 		    else if (envelope1.getMinY() < envelope2.getMinY())
  		    {
  		    	return -1;
  		    }

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/LineStringRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/LineStringRDDTest.java
@@ -6,13 +6,10 @@
  */
 package org.datasyslab.geospark.spatialRDD;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.index.strtree.STRtree;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
@@ -25,17 +22,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- * 
- * @author Arizona State University DataSystems Lab
- *
- */
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.index.quadtree.Quadtree;
-import com.vividsolutions.jts.index.strtree.STRtree;
+/**
+ * @author Arizona State University DataSystems Lab
+ */
 
 // TODO: Auto-generated Javadoc
 /**
@@ -243,7 +237,7 @@ public class LineStringRDDTest {
     public void testMBR() throws Exception {
     	LineStringRDD lineStringRDD = new LineStringRDD(sc, InputLocation, splitter, true, numPartitions,StorageLevel.MEMORY_ONLY());
     	RectangleRDD rectangleRDD=lineStringRDD.MinimumBoundingRectangle();
-    	List<Object> result = rectangleRDD.rawSpatialRDD.collect();
+    	List<Polygon> result = rectangleRDD.rawSpatialRDD.collect();
     	assert result.size()>-1;
     }  
     

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/PolygonRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/PolygonRDDTest.java
@@ -6,13 +6,10 @@
  */
 package org.datasyslab.geospark.spatialRDD;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.index.strtree.STRtree;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
@@ -25,17 +22,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- * 
- * @author Arizona State University DataSystems Lab
- *
- */
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.index.quadtree.Quadtree;
-import com.vividsolutions.jts.index.strtree.STRtree;
+/**
+ * @author Arizona State University DataSystems Lab
+ */
 
 // TODO: Auto-generated Javadoc
 /**
@@ -255,7 +249,7 @@ public class PolygonRDDTest {
     public void testMBR() throws Exception {
     	PolygonRDD polygonRDD = new PolygonRDD(sc, InputLocation, splitter, true, numPartitions,StorageLevel.MEMORY_ONLY());
     	RectangleRDD rectangleRDD=polygonRDD.MinimumBoundingRectangle();
-    	List<Object> result = rectangleRDD.rawSpatialRDD.collect();
+    	List<Polygon> result = rectangleRDD.rawSpatialRDD.collect();
     	assert result.size()>-1;
     }  
     


### PR DESCRIPTION
Allow creating SpatialRDD with a mix of geometry types by making SpatialRDD a generic class parameterized over geometry type. Restricting objects stored in Spatial RDD to instances of Geometry enhances type safety and reduces the need for dynamic cast.

Updated core/pom.xml to add dependencies to allow 'mvn clean install' to succeed.