### PR TITLE
Allow joining SpatialRDD<T> with SpatialRDD<Polygon>

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/PairGeometry.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/PairGeometry.java
@@ -7,37 +7,21 @@
 package org.datasyslab.geospark.geometryObjects;
 
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
 import scala.Tuple2;
 
 import java.io.Serializable;
 import java.util.HashSet;
 
-public class PairGeometry implements Serializable {
-    public Geometry keyGeometry;
-    public HashSet valueGeometries;
-    public PairGeometry(Geometry keyGeometry, HashSet valueGeometries)
+public class PairGeometry<K extends Geometry, V extends Geometry> implements Serializable {
+    public K keyGeometry;
+    public HashSet<V> valueGeometries;
+    public PairGeometry(K keyGeometry, HashSet<V> valueGeometries)
     {
         this.keyGeometry = keyGeometry;
         this.valueGeometries = valueGeometries;
     }
-    public Tuple2<Polygon,HashSet<Geometry>> getPolygonTuple2()
-    {
-        return new Tuple2<Polygon,HashSet<Geometry>>((Polygon) keyGeometry,valueGeometries);
-    }
-    public Tuple2<Point,HashSet<Geometry>> getPointTuple2()
-    {
-        return new Tuple2<Point,HashSet<Geometry>>((Point) keyGeometry,valueGeometries);
-    }
-    public Tuple2<LineString,HashSet<Geometry>> getLineStringTuple2()
-    {
-        return new Tuple2<LineString,HashSet<Geometry>>((LineString) keyGeometry,valueGeometries);
-    }
-    public Tuple2<Circle,HashSet<Geometry>> getCircleTuple2()
-    {
-        return new Tuple2<Circle,HashSet<Geometry>>((Circle) keyGeometry,valueGeometries);
+    public Tuple2<K, HashSet<V>> makeTuple2() {
+        return new Tuple2<>(keyGeometry, valueGeometries);
     }
 
     @Override

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByCircleJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByCircleJudgement.java
@@ -8,10 +8,8 @@ package org.datasyslab.geospark.joinJudgement;
 
 import com.vividsolutions.jts.geom.Geometry;
 import org.apache.spark.api.java.function.FlatMapFunction2;
-import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.datasyslab.geospark.geometryObjects.Circle;
 import org.datasyslab.geospark.geometryObjects.PairGeometry;
-import scala.Tuple2;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,7 +23,7 @@ import java.util.List;
 /**
  * The Class GeometryByCircleJudgement.
  */
-public class GeometryByCircleJudgement implements FlatMapFunction2<Iterator<Object>, Iterator<Object>, PairGeometry>, Serializable {
+public class GeometryByCircleJudgement<T extends Geometry> implements FlatMapFunction2<Iterator<T>, Iterator<Circle>, PairGeometry<Circle, T>>, Serializable {
 
     /**
      * The consider boundary intersection.
@@ -42,9 +40,9 @@ public class GeometryByCircleJudgement implements FlatMapFunction2<Iterator<Obje
     }
 
     @Override
-    public Iterator<PairGeometry> call(Iterator<Object> iteratorObject, Iterator<Object> iteratorWindow) throws Exception {
-        List<PairGeometry> result = new ArrayList<PairGeometry>();
-        List<Object> queryObjects = new ArrayList<Object>();
+    public Iterator<PairGeometry<Circle, T>> call(Iterator<T> iteratorObject, Iterator<Circle> iteratorWindow) throws Exception {
+        List<PairGeometry<Circle, T>> result = new ArrayList<>();
+        List<T> queryObjects = new ArrayList<>();
         while(iteratorObject.hasNext())
         {
             queryObjects.add(iteratorObject.next());

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByPolygonJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByPolygonJudgement.java
@@ -9,9 +9,7 @@ package org.datasyslab.geospark.joinJudgement;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
 import org.apache.spark.api.java.function.FlatMapFunction2;
-import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.datasyslab.geospark.geometryObjects.PairGeometry;
-import scala.Tuple2;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -24,7 +22,7 @@ import java.util.List;
 /**
  * The Class GeometryByPolygonJudgement.
  */
-public class GeometryByPolygonJudgement implements FlatMapFunction2<Iterator<Object>, Iterator<Object>, PairGeometry>, Serializable {
+public class GeometryByPolygonJudgement<T extends Geometry> implements FlatMapFunction2<Iterator<T>, Iterator<Polygon>, PairGeometry<Polygon, T>>, Serializable {
 
     /**
      * The consider boundary intersection.
@@ -41,18 +39,18 @@ public class GeometryByPolygonJudgement implements FlatMapFunction2<Iterator<Obj
     }
 
     @Override
-    public Iterator<PairGeometry> call(Iterator<Object> iteratorObject, Iterator<Object> iteratorWindow) throws Exception {
-        List<PairGeometry> result = new ArrayList<PairGeometry>();
-        List<Object> queryObjects = new ArrayList<Object>();
+    public Iterator<PairGeometry<Polygon, T>> call(Iterator<T> iteratorObject, Iterator<Polygon> iteratorWindow) throws Exception {
+        List<PairGeometry<Polygon, T>> result = new ArrayList<>();
+        List<T> queryObjects = new ArrayList<>();
         while(iteratorObject.hasNext())
         {
             queryObjects.add(iteratorObject.next());
         }
         while (iteratorWindow.hasNext()) {
-            Polygon window = (Polygon) iteratorWindow.next();
+            Polygon window = iteratorWindow.next();
             HashSet<Geometry> resultHashSet = new HashSet<Geometry>();
             for (int i =0;i<queryObjects.size();i++) {
-                Geometry object = (Geometry) queryObjects.get(i);
+                Geometry object = queryObjects.get(i);
                 if (considerBoundaryIntersection) {
                     if (window.intersects(object)) {
                         resultHashSet.add(object);

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByPolygonJudgementUsingIndex.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/GeometryByPolygonJudgementUsingIndex.java
@@ -9,13 +9,8 @@ package org.datasyslab.geospark.joinJudgement;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.index.SpatialIndex;
-import com.vividsolutions.jts.index.quadtree.Quadtree;
-import com.vividsolutions.jts.index.strtree.STRtree;
-import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.FlatMapFunction2;
-import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.datasyslab.geospark.geometryObjects.PairGeometry;
-import scala.Tuple2;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,7 +23,7 @@ import java.util.List;
 /**
  * The Class GeometryByPolygonJudgementUsingIndex.
  */
-public class GeometryByPolygonJudgementUsingIndex implements FlatMapFunction2<Iterator<SpatialIndex>, Iterator<Object>, PairGeometry>, Serializable {
+public class GeometryByPolygonJudgementUsingIndex<T extends Geometry> implements FlatMapFunction2<Iterator<SpatialIndex>, Iterator<Polygon>, PairGeometry<Polygon, T>>, Serializable {
 
     /**
      * The consider boundary intersection.
@@ -45,22 +40,16 @@ public class GeometryByPolygonJudgementUsingIndex implements FlatMapFunction2<It
     }
 
     @Override
-    public Iterator<PairGeometry> call(Iterator<SpatialIndex> iteratorTree, Iterator<Object> iteratorWindow) throws Exception {
-        List<PairGeometry> result = new ArrayList<>();
+    public Iterator<PairGeometry<Polygon, T>> call(Iterator<SpatialIndex> iteratorTree, Iterator<Polygon> iteratorWindow) throws Exception {
+        List<PairGeometry<Polygon, T>> result = new ArrayList<>();
 
         if (!iteratorTree.hasNext()) {
             return result.iterator();
         }
         SpatialIndex treeIndex = iteratorTree.next();
-        if (treeIndex instanceof STRtree) {
-            treeIndex = (STRtree) treeIndex;
-        } else {
-            treeIndex = (Quadtree) treeIndex;
-        }
         while (iteratorWindow.hasNext()) {
-            Polygon window = (Polygon) iteratorWindow.next();
-            List<Geometry> queryResult = new ArrayList<Geometry>();
-            queryResult = treeIndex.query(window.getEnvelopeInternal());
+            Polygon window = iteratorWindow.next();
+            List<Geometry> queryResult = treeIndex.query(window.getEnvelopeInternal());
             if (queryResult.size() == 0) continue;
             HashSet<Geometry> objectHashSet = new HashSet<Geometry>();
             for (Geometry spatialObject : queryResult) {

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/DuplicatesHandler.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/DuplicatesHandler.java
@@ -6,14 +6,11 @@
  */
 package org.datasyslab.geospark.spatialPartitioning;
 
-import java.util.HashSet;
-
+import com.vividsolutions.jts.geom.Geometry;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function2;
-import org.datasyslab.geospark.geometryObjects.Circle;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
+import java.util.HashSet;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -27,29 +24,11 @@ public class DuplicatesHandler {
      * @param joinResultBeforeAggregation the join result before aggregation
      * @return the java pair RDD
      */
-    public static JavaPairRDD<Polygon, HashSet<Geometry>> removeDuplicatesGeometryByPolygon(JavaPairRDD<Polygon, HashSet<Geometry>> joinResultBeforeAggregation) {
+    public static <K extends Geometry, T extends Geometry> JavaPairRDD<K, HashSet<T>> removeDuplicates(JavaPairRDD<K, HashSet<T>> joinResultBeforeAggregation) {
             //AggregateByKey?
-            JavaPairRDD<Polygon, HashSet<Geometry>> joinResultAfterAggregation = joinResultBeforeAggregation.reduceByKey(new Function2<HashSet<Geometry>, HashSet<Geometry>, HashSet<Geometry>>() {
+            JavaPairRDD<K, HashSet<T>> joinResultAfterAggregation = joinResultBeforeAggregation.reduceByKey(new Function2<HashSet<T>, HashSet<T>, HashSet<T>>() {
                 @Override
-                public HashSet<Geometry> call(HashSet<Geometry> geometries, HashSet<Geometry> otherGeometries) throws Exception {
-                	geometries.addAll(otherGeometries);
-                    return geometries;
-                }
-            });
-        return joinResultAfterAggregation;
-    }
-    
-    /**
-     * Removes the duplicates geometry by polygon.
-     *
-     * @param joinResultBeforeAggregation the join result before aggregation
-     * @return the java pair RDD
-     */
-    public static JavaPairRDD<Circle, HashSet<Geometry>> removeDuplicatesGeometryByCircle(JavaPairRDD<Circle, HashSet<Geometry>> joinResultBeforeAggregation) {
-            //AggregateByKey?
-            JavaPairRDD<Circle, HashSet<Geometry>> joinResultAfterAggregation = joinResultBeforeAggregation.reduceByKey(new Function2<HashSet<Geometry>, HashSet<Geometry>, HashSet<Geometry>>() {
-                @Override
-                public HashSet<Geometry> call(HashSet<Geometry> geometries, HashSet<Geometry> otherGeometries) throws Exception {
+                public HashSet<T> call(HashSet<T> geometries, HashSet<T> otherGeometries) throws Exception {
                 	geometries.addAll(otherGeometries);
                     return geometries;
                 }


### PR DESCRIPTION
Generalize join APIs to allow joins between generic SpatialRDD<T> and SpatialRDD<Polygon>.