### PR TITLE
Fix QuadRectange.contains to process envelopes of points correctly

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangle.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangle.java
@@ -11,8 +11,9 @@ import com.vividsolutions.jts.geom.Envelope;
 import java.io.Serializable;
 
 public class QuadRectangle implements Serializable{
-    public double x, y, width, height;
+    public final double x, y, width, height;
     public Integer partitionId = -1;
+
     public QuadRectangle(Envelope envelope)
     {
         this.x = envelope.getMinX();
@@ -20,7 +21,16 @@ public class QuadRectangle implements Serializable{
         this.width = envelope.getWidth();
         this.height = envelope.getHeight();
     }
+
     public QuadRectangle(double x, double y, double width, double height) {
+        if (width < 0) {
+            throw new IllegalArgumentException("width must be >= 0");
+        }
+
+        if (height < 0) {
+            throw new IllegalArgumentException("height must be >= 0");
+        }
+
         this.x = x;
         this.y = y;
         this.width = width;
@@ -28,14 +38,12 @@ public class QuadRectangle implements Serializable{
     }
 
     public boolean contains(int x, int y) {
-        return this.width > 0 && this.height > 0
-                && x >= this.x && x <= this.x + this.width
+        return x >= this.x && x <= this.x + this.width
                 && y >= this.y && y <= this.y + this.height;
     }
 
     public boolean contains(QuadRectangle r) {
-        return this.width > 0 && this.height > 0 && r.width > 0 && r.height > 0
-                && r.x >= this.x && r.x + r.width <= this.x + this.width
+        return r.x >= this.x && r.x + r.width <= this.x + this.width
                 && r.y >= this.y && r.y + r.height <= this.y + this.height;
     }
     /*

--- a/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangleTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangleTest.java
@@ -15,14 +15,24 @@ public class QuadRectangleTest {
 
     @Test
     public void testContains() {
-        QuadRectangle r1 = new QuadRectangle(0, 0, 10, 10);
-        QuadRectangle r2 = new QuadRectangle(0, 0, 10, 10);
+        QuadRectangle r1 = makeRect(0, 0, 10, 10);
+        QuadRectangle r2 = makeRect(0, 0, 10, 10);
 
-        // contains
+        // contains rectange
         assertTrue(r1.contains(r2));
 
-        // dont contains
-        r2.width = 11;
-        assertFalse(r1.contains(r2));
+        // contains point
+        assertTrue(r1.contains(makeRect(5, 5, 0, 0)));
+
+        // doesn't contain rectangle
+        QuadRectangle r3 = makeRect(0, 0, 11, 10);
+        assertFalse(r1.contains(r3));
+
+        // doesn't contain point
+        assertFalse(r1.contains(makeRect(5, 12, 0, 0)));
+    }
+
+    private QuadRectangle makeRect(double x, double y, double width, double height) {
+        return new QuadRectangle(x, y, width, height);
     }
 }


### PR DESCRIPTION
QuadRectange.contains used to return false for all rectangles of zero width or height including all rectangles which represent envelopes of points. As a result quad-tree partitioning of RDD of points never created more than 5 partitions making join operations very slow for large datasets. This PR fixes QuadRectange.contains to properly handle zero width or height rectangles.