### PR TITLE
Allow mix-and-match of geometry types on both sides of a join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target/
 /.idea
-/GeoSpark.iml
+/*.iml
 /.settings/
 /.classpath
 /.project

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/IndexLookupJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/IndexLookupJudgement.java
@@ -7,7 +7,6 @@
 package org.datasyslab.geospark.joinJudgement;
 
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.index.SpatialIndex;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.spark.api.java.function.FlatMapFunction2;
@@ -17,13 +16,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class IndexLookupJudgement<T extends Geometry>
+public class IndexLookupJudgement<T extends Geometry, U extends Geometry>
         extends JudgementBase
-        implements FlatMapFunction2<Iterator<SpatialIndex>, Iterator<Polygon>, Pair<Polygon, T>>, Serializable {
+        implements FlatMapFunction2<Iterator<SpatialIndex>, Iterator<U>, Pair<U, T>>, Serializable {
 
     /**
-     * Instantiates a new geometry by polygon judgement using index.
-     *
      * @param considerBoundaryIntersection the consider boundary intersection
      */
     public IndexLookupJudgement(boolean considerBoundaryIntersection) {
@@ -31,8 +28,8 @@ public class IndexLookupJudgement<T extends Geometry>
     }
 
     @Override
-    public Iterator<Pair<Polygon, T>> call(Iterator<SpatialIndex> iteratorTree, Iterator<Polygon> iteratorWindow) throws Exception {
-        List<Pair<Polygon, T>> result = new ArrayList<>();
+    public Iterator<Pair<U, T>> call(Iterator<SpatialIndex> iteratorTree, Iterator<U> iteratorWindow) throws Exception {
+        List<Pair<U, T>> result = new ArrayList<>();
 
         if (!iteratorTree.hasNext()) {
             return result.iterator();
@@ -40,7 +37,7 @@ public class IndexLookupJudgement<T extends Geometry>
 
         SpatialIndex treeIndex = iteratorTree.next();
         while (iteratorWindow.hasNext()) {
-            Polygon window = iteratorWindow.next();
+            U window = iteratorWindow.next();
             List<Geometry> queryResult = treeIndex.query(window.getEnvelopeInternal());
             if (queryResult.size() == 0) continue;
             for (Geometry spatialObject : queryResult) {

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/JudgementBase.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/JudgementBase.java
@@ -1,7 +1,6 @@
 package org.datasyslab.geospark.joinJudgement;
 
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
 
 import java.io.Serializable;
 
@@ -12,7 +11,7 @@ abstract class JudgementBase implements Serializable {
         this.considerBoundaryIntersection = considerBoundaryIntersection;
     }
 
-    protected boolean match(Polygon polygon, Geometry geometry) {
+    protected boolean match(Geometry polygon, Geometry geometry) {
         return considerBoundaryIntersection ? polygon.intersects(geometry) : polygon.covers(geometry);
     }
 }

--- a/core/src/main/java/org/datasyslab/geospark/joinJudgement/NestedLoopJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/joinJudgement/NestedLoopJudgement.java
@@ -7,7 +7,6 @@
 package org.datasyslab.geospark.joinJudgement;
 
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.spark.api.java.function.FlatMapFunction2;
 
@@ -16,13 +15,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class NestedLoopJudgement<T extends Geometry>
+public class NestedLoopJudgement<T extends Geometry, U extends Geometry>
         extends JudgementBase
-        implements FlatMapFunction2<Iterator<T>, Iterator<Polygon>, Pair<Polygon, T>>, Serializable {
+        implements FlatMapFunction2<Iterator<T>, Iterator<U>, Pair<U, T>>, Serializable {
 
     /**
-     * Instantiates a new geometry by polygon judgement.
-     *
      * @param considerBoundaryIntersection the consider boundary intersection
      */
     public NestedLoopJudgement(boolean considerBoundaryIntersection) {
@@ -30,15 +27,15 @@ public class NestedLoopJudgement<T extends Geometry>
     }
 
     @Override
-    public Iterator<Pair<Polygon, T>> call(Iterator<T> iteratorObject, Iterator<Polygon> iteratorWindow) throws Exception {
-        List<Pair<Polygon, T>> result = new ArrayList<>();
+    public Iterator<Pair<U, T>> call(Iterator<T> iteratorObject, Iterator<U> iteratorWindow) throws Exception {
+        List<Pair<U, T>> result = new ArrayList<>();
         List<T> queryObjects = new ArrayList<>();
         while(iteratorObject.hasNext())
         {
             queryObjects.add(iteratorObject.next());
         }
         while (iteratorWindow.hasNext()) {
-            Polygon window = iteratorWindow.next();
+            U window = iteratorWindow.next();
             for (int i =0;i<queryObjects.size();i++) {
                 T object = queryObjects.get(i);
                 if (match(window, object)) {


### PR DESCRIPTION
Updated the signature of the JoinQuery.spatialJoin API to allow mix-and-match of geometry types on both sides of the join. In practice, this allows to perform joins against a mix of polygons and multi-polygons.