### PR TITLE
Simplified partition ID assignment in StandardQuadTree

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/PartitionJudgement.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/PartitionJudgement.java
@@ -13,10 +13,10 @@ import org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree;
 import scala.Tuple2;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 // TODO: Auto-generated Javadoc
@@ -61,28 +61,20 @@ public class PartitionJudgement implements Serializable{
 		return result.iterator();
 	}
 
-	public static <T extends Geometry> Iterator<Tuple2<Integer, T>> getPartitionID(StandardQuadTree partitionTree, T spatialObject) throws Exception {
-		Set<Tuple2<Integer, T>> result = new HashSet<>();
-		boolean containFlag = false;
-		ArrayList<QuadRectangle> matchedPartitions = new ArrayList<QuadRectangle>();
-		try {
-			partitionTree.getZone(matchedPartitions, new QuadRectangle((spatialObject).getEnvelopeInternal()));
-		}
-		catch (NullPointerException e)
-		{
-			return result.iterator();
-		}
-		for(int i=0;i<matchedPartitions.size();i++)
-		{
-			containFlag=true;
-			result.add(new Tuple2(matchedPartitions.get(i).partitionId, spatialObject));
-		}
+	public static <T extends Geometry> Iterator<Tuple2<Integer, T>> getPartitionID(
+		StandardQuadTree partitionTree,
+		T spatialObject) throws Exception {
 
-		if (containFlag == false) {
-			//throw new Exception("This object cannot find partition: " +spatialObject);
+		Objects.requireNonNull(partitionTree, "partitionTree");
+		Objects.requireNonNull(spatialObject, "spatialObject");
 
-			// This object is not covered by the partition. Should be dropped.
-			// Partition tree from StandardQuadTree do not have missed objects.
+		final Envelope envelope = spatialObject.getEnvelopeInternal();
+
+		final List<QuadRectangle> matchedPartitions = partitionTree.findZones(new QuadRectangle(envelope));
+
+		final Set<Tuple2<Integer, T>> result = new HashSet<>();
+		for (QuadRectangle rectangle : matchedPartitions) {
+			result.add(new Tuple2(rectangle.partitionId, spatialObject));
 		}
 		return result.iterator();
 	}

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
@@ -12,67 +12,40 @@ import org.datasyslab.geospark.spatialPartitioning.quadtree.QuadRectangle;
 import org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-
-// TODO: Auto-generated Javadoc
 
 public class QuadtreePartitioning implements Serializable {
 
     /**
-     * The grids.
+     * The Quad-Tree.
      */
-    private StandardQuadTree<Integer> partitionTree = null;
+    private final StandardQuadTree<Integer> partitionTree;
+
     /**
-     * Instantiates a new rtree partitioning.
+     * Instantiates a new Quad-Tree partitioning.
      *
-     * @param SampleList the sample list
+     * @param samples the sample list
      * @param boundary   the boundary
      * @param partitions the partitions
-     * @throws Exception the exception
      */
-    public QuadtreePartitioning(List SampleList, Envelope boundary, int partitions) throws Exception {
-        StandardQuadTree.maxItemByNode = SampleList.size() / partitions;
-        StandardQuadTree.maxLevel = 100000;
-        partitionTree = new StandardQuadTree(new QuadRectangle(boundary.getMinX(),boundary.getMinY(),boundary.getWidth(),boundary.getHeight()), 0);
-        for (int i = 0; i < SampleList.size(); i++) {
-            if (SampleList.get(i) instanceof Envelope) {
-                Envelope spatialObject = (Envelope) SampleList.get(i);
-                partitionTree.insert(new QuadRectangle(spatialObject), 1);
-            } else if (SampleList.get(i) instanceof Geometry) {
-                Geometry spatialObject = (Geometry) SampleList.get(i);
-                partitionTree.insert(new QuadRectangle(spatialObject.getEnvelopeInternal()), 1);
-            } else {
-                throw new Exception("[QuadtreePartitioning][Constrcutor] Unsupported spatial object type");
-            }
-        }
-        HashSet<Integer> uniqueIdList = new HashSet<Integer>();
-        partitionTree.getAllLeafNodeUniqueId(uniqueIdList);
-        HashMap<Integer,Integer> serialIdMapping = partitionTree.getSeriaIdMapping(uniqueIdList);
-        partitionTree.decidePartitionSerialId(serialIdMapping);
+    public QuadtreePartitioning(List<? extends Geometry> samples, Envelope boundary, int partitions) throws Exception {
+        this(samples, boundary, partitions, -1);
     }
 
-    public QuadtreePartitioning(List SampleList, Envelope boundary, int partitions, int minTreeLevel) throws Exception {
-        StandardQuadTree.maxItemByNode = SampleList.size() / partitions;
-        StandardQuadTree.maxLevel = 100000;
-        partitionTree = new StandardQuadTree(new QuadRectangle(boundary.getMinX(),boundary.getMinY(),boundary.getWidth(),boundary.getHeight()), 0);
-        partitionTree.forceGrowUp(minTreeLevel);
-        for (int i = 0; i < SampleList.size(); i++) {
-            if (SampleList.get(i) instanceof Envelope) {
-                Envelope spatialObject = (Envelope) SampleList.get(i);
-                partitionTree.insert(new QuadRectangle(spatialObject), 1);
-            } else if (SampleList.get(i) instanceof Geometry) {
-                Geometry spatialObject = (Geometry) SampleList.get(i);
-                partitionTree.insert(new QuadRectangle(spatialObject.getEnvelopeInternal()), 1);
-            } else {
-                throw new Exception("[QuadtreePartitioning][Constrcutor] Unsupported spatial object type");
-            }
+    public QuadtreePartitioning(List<? extends Geometry> samples, Envelope boundary, final int partitions, int minTreeLevel)
+            throws Exception {
+        partitionTree = new StandardQuadTree(new QuadRectangle(boundary), 0,
+            samples.size() / partitions, 100000);
+        if (minTreeLevel > 0) {
+            partitionTree.forceGrowUp(minTreeLevel);
         }
-        HashSet<Integer> uniqueIdList = new HashSet<Integer>();
-        partitionTree.getAllLeafNodeUniqueId(uniqueIdList);
-        HashMap<Integer,Integer> serialIdMapping = partitionTree.getSeriaIdMapping(uniqueIdList);
-        partitionTree.decidePartitionSerialId(serialIdMapping);
+
+        for (final Geometry sample : samples) {
+            final Envelope envelope = sample.getEnvelopeInternal();
+            partitionTree.insert(new QuadRectangle(envelope), 1);
+        }
+
+        partitionTree.assignPartitionIds();
     }
 
     public StandardQuadTree getPartitionTree()

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangle.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadRectangle.java
@@ -70,6 +70,18 @@ public class QuadRectangle implements Serializable{
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (o == null || ! (o instanceof QuadRectangle)) {
+            return false;
+        }
+
+        final QuadRectangle other = (QuadRectangle) o;
+        return this.x == other.x && this.y == other.y
+            && this.width == other.width && this.height == other.height
+            && this.partitionId == other.partitionId;
+    }
+
+    @Override
     public int hashCode()
     {
         String stringId = ""+x+y+width+height;

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/StandardQuadTree.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/quadtree/StandardQuadTree.java
@@ -7,35 +7,29 @@
 package org.datasyslab.geospark.spatialPartitioning.quadtree;
 
 import com.vividsolutions.jts.geom.Envelope;
+import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.List;
 
-public class StandardQuadTree<T> implements Serializable{
+public class StandardQuadTree<T> implements Serializable {
+    // Maximum number of items in any given zone. When reached, a zone is sub-divided.
+    private final int maxItemsPerZone;
+    private final int maxLevel;
 
-    // the current nodes
-    ArrayList<QuadNode<T>> nodes = new ArrayList<QuadNode<T>>();
-
-    // current rectangle zone
-    private QuadRectangle zone;
-
-    private int serialId = -1;
-
-    // GLOBAL CONFIGRATION
-    // if this is reached,
-    // the zone is subdivised
-    public static int maxItemByNode = 5;
-    public static int maxLevel = 10;
-
-    int level;
-    int nodeNum=0;
+    private final int level;
+    private int nodeNum=0;
     
     // the four sub regions,
     // may be null if not needed
-    StandardQuadTree<T>[] regions;
+    private StandardQuadTree<T>[] regions;
+
+    // the current nodes
+    private final List<QuadNode<T>> nodes = new ArrayList<>();
+
+    // current rectangle zone
+    private final QuadRectangle zone;
 
     public static final int REGION_SELF = -1;
     public static final int REGION_NW = 0;
@@ -44,18 +38,23 @@ public class StandardQuadTree<T> implements Serializable{
     public static final int REGION_SE = 3;
 
     public StandardQuadTree(QuadRectangle definition, int level) {
-        zone = definition;
-        nodes = new ArrayList<QuadNode<T>>();
+        this(definition, level, 5, 10);
+    }
+
+    public StandardQuadTree(QuadRectangle definition, int level, int maxItemsPerZone, int maxLevel) {
+        this.maxItemsPerZone = maxItemsPerZone;
+        this.maxLevel = maxLevel;
+        this.zone = definition;
         this.level = level;
     }
 
-    protected QuadRectangle getZone() {
+    public QuadRectangle getZone() {
         return this.zone;
     }
 
     private int findRegion(QuadRectangle r, boolean split) {
         int region = REGION_SELF;
-        if (nodeNum >= maxItemByNode && this.level < maxLevel) {
+        if (nodeNum >= maxItemsPerZone && this.level < maxLevel) {
             // we don't want to split if we just need to retrieve
             // the region, not inserting an element
             if (regions == null && split) {
@@ -65,36 +64,36 @@ public class StandardQuadTree<T> implements Serializable{
 
             // can be null if not splitted
             if (regions != null) {
-                if (regions[REGION_NW].getZone().contains(r)) {
-                    region = REGION_NW;
-                } else if (regions[REGION_NE].getZone().contains(r)) {
-                    region = REGION_NE;
-                } else if (regions[REGION_SW].getZone().contains(r)) {
-                    region = REGION_SW;
-                } else if (regions[REGION_SE].getZone().contains(r)) {
-                    region = REGION_SE;
+                for (int i=0; i<regions.length; i++) {
+                    if (regions[i].getZone().contains(r)) {
+                        region = i;
+                        break;
+                    }
                 }
             }
         }
 
         return region;
     }
+
     private int findRegion(int x, int y) {
         int region = REGION_SELF;
-            // can be null if not splitted
-            if (regions != null) {
-                if (regions[REGION_NW].getZone().contains(x,y)) {
-                    region = REGION_NW;
-                } else if (regions[REGION_NE].getZone().contains(x,y)) {
-                    region = REGION_NE;
-                } else if (regions[REGION_SW].getZone().contains(x,y)) {
-                    region = REGION_SW;
-                } else if (regions[REGION_SE].getZone().contains(x,y)) {
-                    region = REGION_SE;
+        // can be null if not splitted
+        if (regions != null) {
+            for (int i=0; i<regions.length; i++) {
+                if (regions[i].getZone().contains(x, y)) {
+                    region = i;
+                    break;
                 }
+            }
         }
         return region;
     }
+
+    private StandardQuadTree<T> newQuadTree(QuadRectangle zone, int level) {
+        return new StandardQuadTree<T>(zone, level, this.maxItemsPerZone, this.maxLevel);
+    }
+
     private void split() {
 
         regions = new StandardQuadTree[4];
@@ -103,28 +102,28 @@ public class StandardQuadTree<T> implements Serializable{
         double newHeight = zone.height / 2;
         int newLevel = level + 1;
 
-        regions[REGION_NW] = new StandardQuadTree<T>(new QuadRectangle(
+        regions[REGION_NW] = newQuadTree(new QuadRectangle(
                 zone.x,
                 zone.y + zone.height / 2,
                 newWidth,
                 newHeight
         ), newLevel);
 
-        regions[REGION_NE] = new StandardQuadTree<T>(new QuadRectangle(
+        regions[REGION_NE] = newQuadTree(new QuadRectangle(
                 zone.x + zone.width / 2,
                 zone.y + zone.height / 2,
                 newWidth,
                 newHeight
         ), newLevel);
 
-        regions[REGION_SW] = new StandardQuadTree<T>(new QuadRectangle(
+        regions[REGION_SW] = newQuadTree(new QuadRectangle(
                 zone.x,
                 zone.y,
                 newWidth,
                 newHeight
         ), newLevel);
 
-        regions[REGION_SE] = new StandardQuadTree<T>(new QuadRectangle(
+        regions[REGION_SE] = newQuadTree(new QuadRectangle(
                 zone.x + zone.width / 2,
                 zone.y,
                 newWidth,
@@ -132,25 +131,23 @@ public class StandardQuadTree<T> implements Serializable{
         ), newLevel);
     }
 
-    // Force the quad tree to grow up to a certain level. The number of
+    // Force the quad tree to grow up to a certain level.
     public void forceGrowUp(int minLevel)
     {
-        assert minLevel>=1;
-        split();
-       	nodeNum = maxItemByNode;
-        if(level+1>=minLevel)
-        {
-            return;
+        if (minLevel < 1) {
+            throw new IllegalArgumentException("minLevel must be >= 1. Received " + minLevel);
         }
-        else
+
+        split();
+        nodeNum = maxItemsPerZone;
+        if(level + 1 >= minLevel)
         {
-            regions[REGION_NW].forceGrowUp(minLevel);
-            regions[REGION_NE].forceGrowUp(minLevel);
-            regions[REGION_SW].forceGrowUp(minLevel);
-            regions[REGION_SE].forceGrowUp(minLevel);
             return;
         }
 
+        for (StandardQuadTree<T> region : regions) {
+            region.forceGrowUp(minLevel);
+        }
     }
 
     public void insert(QuadRectangle r, T element) {
@@ -163,123 +160,126 @@ public class StandardQuadTree<T> implements Serializable{
             regions[region].insert(r, element);
         }
 
-        if (nodeNum >= maxItemByNode && this.level < maxLevel) {
+        if (nodeNum >= maxItemsPerZone && this.level < maxLevel) {
             // redispatch the elements
-            ArrayList<QuadNode<T>> tempNodes = new ArrayList<QuadNode<T>>();
-            int length = nodes.size();
-            for (int i = 0; i < length; i++) {
-                tempNodes.add(nodes.get(i));
+            List<QuadNode<T>> tempNodes = new ArrayList<>();
+            tempNodes.addAll(nodes);
 
-            }
             nodes.clear();
-
             for (QuadNode<T> node : tempNodes) {
                 this.insert(node.r, node.element);
             }
         }
     }
 
-    public ArrayList<T> getElements(ArrayList<T> list, QuadRectangle r) {
+    public List<T> getElements(QuadRectangle r) {
         int region = this.findRegion(r, false);
 
-        int length = nodes.size();
-        for (int i = 0; i < length; i++) {
-            list.add(nodes.get(i).element);
-        }
+        final List<T> list = new ArrayList<>();
 
         if (region != REGION_SELF) {
-            regions[region].getElements(list, r);
-        } else {
-            getAllElements(list, true);
-        }
-
-        return list;
-    }
-
-    public ArrayList<T> getAllElements(ArrayList<T> list, boolean firstCall) {
-        if (regions != null) {
-            regions[REGION_NW].getAllElements(list, false);
-            regions[REGION_NE].getAllElements(list, false);
-            regions[REGION_SW].getAllElements(list, false);
-            regions[REGION_SE].getAllElements(list, false);
-        }
-
-        if (!firstCall) {
-            int length = nodes.size();
-            for (int i = 0; i < length; i++) {
-                list.add(nodes.get(i).element);
+            for (QuadNode<T> node : nodes) {
+                list.add(node.element);
             }
+
+            list.addAll(regions[region].getElements(r));
+        } else {
+            addAllElements(list);
         }
 
         return list;
     }
 
-    public void getAllZones(ArrayList<QuadRectangle> list) {
-        list.add(this.zone);
+    private interface Visitor<T> {
+        /**
+         * Visits a single node of the tree
+         * @param tree Node to visit
+         * @return true to continue traversing the tree; false to stop
+         */
+        boolean visit(StandardQuadTree<T> tree);
+    }
+
+    /**
+     * Traverses the tree top-down breadth-first and calls the visitor
+     * for each node. Stops traversing if a call to Visitor.visit returns false.
+     */
+    private void traverse(Visitor<T> visitor) {
+        if (!visitor.visit(this)) {
+            return;
+        }
+
         if (regions != null) {
-            regions[REGION_NW].getAllZones(list);
-            regions[REGION_NE].getAllZones(list);
-            regions[REGION_SW].getAllZones(list);
-            regions[REGION_SE].getAllZones(list);
+            regions[REGION_NW].traverse(visitor);
+            regions[REGION_NE].traverse(visitor);
+            regions[REGION_SW].traverse(visitor);
+            regions[REGION_SE].traverse(visitor);
         }
     }
 
-    public void getAllLeafNodeUniqueId(HashSet<Integer> uniqueIdList)
-    {
-        if (regions!= null) {
-            regions[REGION_NW].getAllLeafNodeUniqueId(uniqueIdList);
-            regions[REGION_NE].getAllLeafNodeUniqueId(uniqueIdList);
-            regions[REGION_SW].getAllLeafNodeUniqueId(uniqueIdList);
-            regions[REGION_SE].getAllLeafNodeUniqueId(uniqueIdList);
-        } else {
-            // This is a leaf node
-            uniqueIdList.add(zone.hashCode());
-        }
+
+    private void addAllElements(final List<T> list) {
+        traverse(new Visitor<T>() {
+            @Override
+            public boolean visit(StandardQuadTree<T> tree) {
+                for (QuadNode<T> node : tree.nodes) {
+                    list.add(node.element);
+                }
+                return true;
+            }
+        });
+    }
+
+    public boolean isLeaf() {
+        return regions == null;
+    }
+
+    public List<QuadRectangle> getAllZones() {
+        final List<QuadRectangle> zones = new ArrayList<>();
+        traverse(new Visitor<T>() {
+            @Override
+            public boolean visit(StandardQuadTree<T> tree) {
+                zones.add(tree.zone);
+                return true;
+            }
+        });
+
+        return zones;
     }
 
     public int getTotalNumLeafNode() {
-        if (regions!= null) {
-            return regions[REGION_NW].getTotalNumLeafNode() + regions[REGION_NE].getTotalNumLeafNode()
-                    + regions[REGION_SW].getTotalNumLeafNode() + regions[REGION_SE].getTotalNumLeafNode();
-        } else {
-            // This is a leaf node
-            return 1;
-        }
+        final MutableInt leafCount = new MutableInt(0);
+        traverse(new Visitor<T>() {
+            @Override
+            public boolean visit(StandardQuadTree<T> tree) {
+                if (tree.isLeaf()) {
+                    leafCount.increment();
+                }
+                return true;
+            }
+        });
+
+        return leafCount.getValue();
     }
+
     /**
      * Find the zone that fully contains this query point
      * @param x
      * @param y
      * @return
      */
-    public QuadRectangle getZone(int x, int y) throws ArrayIndexOutOfBoundsException{
+    public QuadRectangle getZone(int x, int y) throws ArrayIndexOutOfBoundsException {
         int region = this.findRegion(x,y);
         if (region != REGION_SELF) {
             return regions[region].getZone(x,y);
         } else {
-            if(this.zone.contains(x, y))
-            {
+            if(this.zone.contains(x, y)) {
                 return this.zone;
             }
-            else
-            {
-                throw new ArrayIndexOutOfBoundsException("[Babylon][StandardQuadTree] this pixel is out of the quad tree boundary.");
-            }
+
+            throw new ArrayIndexOutOfBoundsException("[Babylon][StandardQuadTree] this pixel is out of the quad tree boundary.");
         }
     }
-    /*
-    public QuadRectangle getZone(ArrayList<QuadRectangle> zoneList, QuadRectangle queryRectangle) throws ArrayIndexOutOfBoundsException{
-        if (regions!= null) {
-            regions[REGION_NW].getZone(uniqueIdList, resolutionX, resolutionY);
-            regions[REGION_NE].getZone(uniqueIdList, resolutionX, resolutionY);
-            regions[REGION_SW].getZone(uniqueIdList, resolutionX, resolutionY);
-            regions[REGION_SE].getZone(uniqueIdList, resolutionX, resolutionY);
-        } else {
-            // This is a leaf node
-            uniqueIdList.add(zone.getUniqueId(resolutionX, resolutionY));
-        }
-    }
-    */
+
     public QuadRectangle getParentZone(int x, int y, int minLevel) throws Exception {
         int region = this.findRegion(x, y);
         // Assume this quad tree has done force grow up. Thus, the min tree depth is the min tree level
@@ -300,81 +300,51 @@ public class StandardQuadTree<T> implements Serializable{
                 return regions[region].getParentZone(x, y, minLevel);
             }
         }
-        if (zone.contains(x, y))
-        {
+        if (zone.contains(x, y)) {
             return zone;
         }
-        else
-        {
-            throw new Exception("[Babylon][StandardQuadTree][getParentZone] this pixel is out of the quad tree boundary.");
-        }
+
+        throw new Exception("[Babylon][StandardQuadTree][getParentZone] this pixel is out of the quad tree boundary.");
     }
 
-
-    public void getZone(ArrayList<QuadRectangle> matchedPartitions, QuadRectangle r)
+    public List<QuadRectangle> findZones(QuadRectangle r)
     {
-        // This is a leaf node. Assign a serial Id to this leaf node.
-        if (regions == null)
-        {
-            matchedPartitions.add(zone);
-            return;
-        }
-        else
-        {
-            if (regions != null) {
-                if (!disjoint(regions[REGION_NW].getZone().getEnvelope(),r.getEnvelope())) {
-                    regions[REGION_NW].getZone(matchedPartitions, r);
-                }
-                if (!disjoint(regions[REGION_NE].getZone().getEnvelope(),r.getEnvelope())) {
-                    regions[REGION_NE].getZone(matchedPartitions, r);
-                }
-                if (!disjoint(regions[REGION_SW].getZone().getEnvelope(),r.getEnvelope())) {
-                    regions[REGION_SW].getZone(matchedPartitions, r);
-                }
-                if (!disjoint(regions[REGION_SE].getZone().getEnvelope(),r.getEnvelope())) {
-                    regions[REGION_SE].getZone(matchedPartitions, r);
+        final Envelope envelope = r.getEnvelope();
+
+        final List<QuadRectangle> matches = new ArrayList<>();
+        traverse(new Visitor<T>() {
+            @Override
+            public boolean visit(StandardQuadTree<T> tree) {
+                if (!disjoint(tree.zone.getEnvelope(), envelope)) {
+                    if (tree.isLeaf()) {
+                        matches.add(tree.zone);
+                    }
+                    return true;
+                } else {
+                    return false;
                 }
             }
-        }
-    }
-    public boolean disjoint(Envelope r1, Envelope r2)
-    {
-        if(r1.intersects(r2)||r1.covers(r2)||r2.covers(r1))
-        {
-            return false;
-        }
-        else return true;
+        });
+
+        return matches;
     }
 
-    public HashMap<Integer,Integer> getSeriaIdMapping(HashSet<Integer> uniqueIdList)
-    {
-        int accumulator =0;
-        HashMap<Integer,Integer> idMapping = new HashMap<Integer, Integer>();
-        Iterator<Integer> uniqueIdIterator = uniqueIdList.iterator();
-        while(uniqueIdIterator.hasNext())
-        {
-            int curId = uniqueIdIterator.next();
-            idMapping.put(curId, accumulator);
-            accumulator++;
-        }
-        return idMapping;
+    private boolean disjoint(Envelope r1, Envelope r2) {
+        return !r1.intersects(r2) && !r1.covers(r2) && !r2.covers(r1);
     }
-    public void decidePartitionSerialId(HashMap<Integer, Integer> serialIdMapping)
-    {
-        // This is a leaf node. Assign a serial Id to this leaf node.
-        if (regions == null)
-        {
-            serialId = serialIdMapping.get(zone.hashCode());
-            zone.partitionId = serialId;
-            return;
-        }
-        else
-        {
-            regions[REGION_NW].decidePartitionSerialId(serialIdMapping);
-            regions[REGION_NE].decidePartitionSerialId(serialIdMapping);
-            regions[REGION_SW].decidePartitionSerialId(serialIdMapping);
-            regions[REGION_SE].decidePartitionSerialId(serialIdMapping);
-        }
-        return;
+
+    public void assignPartitionIds() {
+        traverse(new Visitor<T>() {
+            private int partitionId = 0;
+
+            @Override
+            public boolean visit(StandardQuadTree<T> tree) {
+                if (tree.isLeaf()) {
+                    tree.getZone().partitionId = partitionId;
+                    partitionId++;
+                }
+                return true;
+            }
+        });
     }
 }

--- a/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadTreeTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadTreeTest.java
@@ -8,12 +8,12 @@ package org.datasyslab.geospark.spatialPartitioning.quadtree;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class QuadTreeTest {
@@ -26,12 +26,9 @@ public class QuadTreeTest {
         int maxTest = 1000000;
 
 //        startTime = System.currentTimeMillis();
-//        for (int i = 0; i <= maxTest; i++) {
-
-            StandardQuadTree.maxItemByNode = 1;
-            StandardQuadTree.maxLevel = 2;
-
-            StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, 10, 10), 0);
+//        for (int i = 0; i <= maxTest; i++)
+        {
+            StandardQuadTree<QuadRectangle> quadTree = new StandardQuadTree<>(new QuadRectangle(0, 0, 10, 10), 0, 1, 2);
 
             QuadRectangle r1 = new QuadRectangle(1, 1, 1, 1);
             QuadRectangle r2 = new QuadRectangle(2, 2, 1, 1);
@@ -40,76 +37,73 @@ public class QuadTreeTest {
             QuadRectangle r5 = new QuadRectangle(4, 4, 2, 2);
             QuadRectangle r6 = new QuadRectangle(0.5f, 6.5f, 0.5f, 0.5f);
 
-            standardQuadTree.insert(r1, r1);
-            standardQuadTree.insert(r2, r2);
-            standardQuadTree.insert(r3, r3);
-            standardQuadTree.insert(r4, r4);
-            standardQuadTree.insert(r5, r5);
-            standardQuadTree.insert(r6, r6);
-
-            ArrayList<QuadRectangle> list = new ArrayList<QuadRectangle>();
-            standardQuadTree.getElements(list, new QuadRectangle(2, 2, 1, 1));
-
-            ArrayList<QuadRectangle> expected = new ArrayList<QuadRectangle>();
-            expected.add(r1);
-            expected.add(r5);
-            expected.add(r2);
-            expected.add(r3);
-            for(QuadRectangle r:list)
-            {
-            	assert expected.contains(r);
+            for (QuadRectangle r : Arrays.asList(r1, r2, r3, r4, r5, r6)) {
+                quadTree.insert(r, r);
             }
-            assertEquals(expected.size(), list.size());
 
-            list.clear();
-            standardQuadTree.getElements(list, new QuadRectangle(4, 2, 1, 1));
+            List<QuadRectangle> list = quadTree.getElements(new QuadRectangle(2, 2, 1, 1));
 
-            expected.clear();
-            expected.add(r1);
-            expected.add(r5);
-            expected.add(r2);
-            expected.add(r3);
+            assertEqualElements(Arrays.asList(r1, r5, r2, r3), list);
 
-            ArrayList<QuadRectangle> zoneList = new ArrayList<QuadRectangle>();
-            standardQuadTree.getAllZones(zoneList);
+            list = quadTree.getElements(new QuadRectangle(4, 2, 1, 1));
+            assertEqualElements(Arrays.asList(r1, r5, r2, r3), list);
 
-            assertEquals(zoneList.size(), 9);
-//        }
+            list = quadTree.getElements(new QuadRectangle(3, 1, 1, 1));
+            assertEqualElements(Arrays.asList(r2, r5), list);
+
+            list = quadTree.getElements(new QuadRectangle(0, 6, 1, 1));
+            assertEqualElements(Arrays.asList(r6, r5), list);
+
+            list = quadTree.getElements(new QuadRectangle(2, 2, 10, 10));
+            assertEqualElements(Arrays.asList(r1, r2, r3, r4, r5, r6), list);
+
+            final List<QuadRectangle> zones = quadTree.getAllZones();
+            assertEquals(9, zones.size());
+
+            final int leafNodeCount = quadTree.getTotalNumLeafNode();
+            assertEquals(7, leafNodeCount);
+
+            {
+                final List<QuadRectangle> matches =
+                        quadTree.findZones(new QuadRectangle(1.1, 0.8, 1, 1));
+                assertEquals(1, matches.size());
+                assertEquals(new QuadRectangle(0, 0, 2.5, 2.5), matches.get(0));
+            }
+
+            {
+                final List<QuadRectangle> matches =
+                        quadTree.findZones(new QuadRectangle(1.1, 0.8, 10, 10));
+                assertEquals(7, matches.size());
+            }
+        }
 //        endTime = System.currentTimeMillis();
 //        System.out.println("Total execution time hoho: " + (endTime - startTime) + "ms");
     }
 
+    private void assertEqualElements(List<QuadRectangle> expected, List<QuadRectangle> actual) {
+        assertEquals(expected.size(), actual.size());
+        for (QuadRectangle r : actual) {
+            assertTrue(expected.contains(r));
+        }
+    }
+
     @Test
     public void testIntersectElementsAreInserted() {
-        StandardQuadTree.maxItemByNode = 1;
-        StandardQuadTree.maxLevel = 2;
-
-        StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, 10, 10), 0);
+        StandardQuadTree<QuadRectangle> quadTree = new StandardQuadTree<>(new QuadRectangle(0, 0, 10, 10), 0, 1, 2);
 
         QuadRectangle r1 = new QuadRectangle(1, 1, 1, 1);
         QuadRectangle r2 = new QuadRectangle(2, 2, 1, 1);
 
-        standardQuadTree.insert(r1, r1);
-        standardQuadTree.insert(r2, r2);
+        quadTree.insert(r1, r1);
+        quadTree.insert(r2, r2);
 
-        ArrayList<QuadRectangle> list = new ArrayList<QuadRectangle>();
-        standardQuadTree.getElements(list, new QuadRectangle(2, 2, 1, 1));
-
-        assertTrue(list.size() == 2);
-
-
-        QuadRectangle r3 = new QuadRectangle(11, 11, 1, 1);
-
-        list = new ArrayList<QuadRectangle>();
-        standardQuadTree.getElements(list, new QuadRectangle(2, 2, 1, 1));
+        List<QuadRectangle> list = quadTree.getElements(new QuadRectangle(2, 2, 1, 1));
+        assertEqualElements(Arrays.asList(r1, r2), list);
     }
 
     @Test
     public void testPixelQuadTree() {
-        StandardQuadTree.maxItemByNode = 5;
-        StandardQuadTree.maxLevel = 5;
-
-        StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, 10, 10), 0);
+        StandardQuadTree<QuadRectangle> quadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, 10, 10), 0, 5, 5);
 
         QuadRectangle r1 = new QuadRectangle(1, 1, 0, 0);
         QuadRectangle r2 = new QuadRectangle(2, 2, 0, 0);
@@ -118,101 +112,45 @@ public class QuadTreeTest {
         QuadRectangle r5 = new QuadRectangle(4, 4, 2, 2);
         QuadRectangle r6 = new QuadRectangle(0.5f, 6.5f, 0.5f, 0.5f);
 
-        standardQuadTree.insert(r1, r1);
-        standardQuadTree.insert(r2, r2);
-        standardQuadTree.insert(r3, r3);
-        standardQuadTree.insert(r4, r4);
-        standardQuadTree.insert(r5, r5);
-        standardQuadTree.insert(r6, r6);
-
-        ArrayList<QuadRectangle> zoneList = new ArrayList<QuadRectangle>();
-        ArrayList<QuadRectangle> matchedZoneList = new ArrayList<QuadRectangle>();
-
-        standardQuadTree.getAllZones(zoneList);
-        for(QuadRectangle r:zoneList)
-        {
-            if (r.contains(1,1))
-            {
-                matchedZoneList.add(r);
-            }
+        for (QuadRectangle r : Arrays.asList(r1, r2, r3, r4, r5, r6)) {
+            quadTree.insert(r, r);
         }
-        QuadRectangle matchedZone = standardQuadTree.getZone(1,1);
-        assert matchedZoneList.contains(matchedZone);
+
+        assertEquals(new QuadRectangle(0, 0, 5, 5), quadTree.getZone(1, 1));
+        assertEquals(new QuadRectangle(5, 0, 5, 5), quadTree.getZone(6, 1));
+        assertEquals(new QuadRectangle(0, 5, 5, 5), quadTree.getZone(5, 5));
+        assertEquals(new QuadRectangle(5, 5, 5, 5), quadTree.getZone(7, 8));
     }
 
     @Test
     public void testQuadTreeForceGrow() {
-        StandardQuadTree.maxItemByNode = 4;
-        StandardQuadTree.maxLevel = 10;
-
         int resolutionX = 100000;
         int resolutionY = 100000;
 
-        StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, resolutionX, resolutionY), 0);
-        standardQuadTree.forceGrowUp(4);
-        int leafPartitionNum = standardQuadTree.getTotalNumLeafNode();
-        assert leafPartitionNum == 256;
+        StandardQuadTree<QuadRectangle> quadTree = new StandardQuadTree<>(new QuadRectangle(0, 0, resolutionX, resolutionY), 0, 4, 10);
+        quadTree.forceGrowUp(4);
+        int leafPartitionNum = quadTree.getTotalNumLeafNode();
+        assertEquals(256, leafPartitionNum);
     
         for (int i = 0; i < 100000; i++) {
             int x = ThreadLocalRandom.current().nextInt(0, resolutionX);
             int y = ThreadLocalRandom.current().nextInt(0, resolutionY);
             QuadRectangle newR = new QuadRectangle(x, y, 1, 1);
-            standardQuadTree.insert(newR, newR);
+            quadTree.insert(newR, newR);
         }
-        HashSet<Integer> uniqueIdList = new HashSet<Integer>();
-        standardQuadTree.getAllLeafNodeUniqueId(uniqueIdList);
-        HashMap<Integer,Integer> serialIdMapping = standardQuadTree.getSeriaIdMapping(uniqueIdList);
-        standardQuadTree.decidePartitionSerialId(serialIdMapping);
-        ArrayList<QuadRectangle> allNumberedZoneList = new ArrayList<QuadRectangle>();
-        standardQuadTree.getAllZones(allNumberedZoneList);
-    }
-    @Test
-    public void testQuadTreeStressful() {
-        StandardQuadTree.maxItemByNode = 1;
-        StandardQuadTree.maxLevel = 10;
 
-        int resolutionX = 100000;
-        int resolutionY = 100000;
-
-        StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, resolutionX, resolutionY), 0);
+        quadTree.assignPartitionIds();
 
         for (int i = 0; i < 100000; i++) {
             int x = ThreadLocalRandom.current().nextInt(0, resolutionX);
             int y = ThreadLocalRandom.current().nextInt(0, resolutionY);
             QuadRectangle newR = new QuadRectangle(x, y, 1, 1);
-            standardQuadTree.insert(newR, newR);
-        }
 
-        ArrayList<QuadRectangle> zoneList = new ArrayList<QuadRectangle>();
-        ArrayList<QuadRectangle> matchedZoneList = new ArrayList<QuadRectangle>();
-
-        standardQuadTree.getAllZones(zoneList);
-        long  startTimeLoop = System.currentTimeMillis();
-        for (int i = 0; i < 1000; i++){
-            int queryX = ThreadLocalRandom.current().nextInt(0, resolutionX);
-            int queryY = ThreadLocalRandom.current().nextInt(0, resolutionY);
-            for (QuadRectangle r : zoneList) {
-                if (r.contains(queryX,queryY)) {
-                    //System.out.println(r);
-                }
-                }
+            final List<QuadRectangle> zones = quadTree.findZones(newR);
+            assertFalse(zones.isEmpty());
+            for (QuadRectangle zone : zones) {
+                assertTrue(zone.partitionId >= 0);
+            }
         }
-        long  stopTimeLoop = System.currentTimeMillis();
-        System.out.println("Loop all zones consumed time: "+(stopTimeLoop-startTimeLoop));
-        long  startTimeTreeSearch = System.currentTimeMillis();
-        /*
-        for(int i = 0; i < 1000; i++)
-        {
-            int queryX = ThreadLocalRandom.current().nextInt(0, resolutionX);
-            int queryY = ThreadLocalRandom.current().nextInt(0, resolutionY);
-            Pixel queryPixel = new Pixel(queryX, queryY, resolutionX, resolutionY);
-            QuadRectangle matchedZone = standardQuadTree.getZone(queryX,queryY);
-            //System.out.println(matchedZone);
-        }
-        */
-        long  stopTimeTreeSearch = System.currentTimeMillis();
-        System.out.println("Tree search consumed time: "+(stopTimeTreeSearch-startTimeTreeSearch));
-        System.out.println("Total number of leaf nodes are "+ standardQuadTree.getTotalNumLeafNode());
-
     }
 }

--- a/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/RenderQuadTree.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/RenderQuadTree.java
@@ -7,9 +7,7 @@
 package org.datasyslab.geospark.spatialPartitioning.quadtree;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 @SuppressWarnings("serial")
@@ -17,7 +15,7 @@ public class RenderQuadTree extends QuadTreePanel {
 
 	int resolutionX = 600;
 	int resolutionY = 600;
-	protected StandardQuadTree<QuadRectangle> standardQuadTree = new StandardQuadTree<QuadRectangle>(new QuadRectangle(0, 0, resolutionX, resolutionY), 0);;
+	protected StandardQuadTree<QuadRectangle> standardQuadTree;
 
 	public static void main(String[] args) {
 		new RenderQuadTree();
@@ -34,8 +32,7 @@ public class RenderQuadTree extends QuadTreePanel {
 	 * @return
 	 */
 	protected StandardQuadTree<QuadRectangle> createQuadTree() {
-		StandardQuadTree.maxItemByNode = 5;
-		StandardQuadTree.maxLevel = 10;
+		standardQuadTree = new StandardQuadTree<>(new QuadRectangle(0, 0, resolutionX, resolutionY), 0, 5, 10);
 		standardQuadTree.forceGrowUp(3);
 		
 		for(int i = 0;i< 10000;i++)
@@ -56,8 +53,7 @@ public class RenderQuadTree extends QuadTreePanel {
 	}
 
 	private void drawCells(Graphics g) {
-		ArrayList<QuadRectangle> zoneList = new ArrayList<QuadRectangle>();
-		standardQuadTree.getAllZones(zoneList);
+		List<QuadRectangle> zoneList = standardQuadTree.getAllZones();
 		g.setColor(Color.BLACK);
 		for(QuadRectangle r:zoneList)
 		{
@@ -87,23 +83,15 @@ public class RenderQuadTree extends QuadTreePanel {
 
 		g.drawRect((int)quadRectangle.x,(int)quadRectangle.y,(int)quadRectangle.width,(int)quadRectangle.height);
 
-
-		HashSet<Integer> uniqueIdList = new HashSet<Integer>();
-		standardQuadTree.getAllLeafNodeUniqueId(uniqueIdList);
-		HashMap<Integer,Integer> serialIdMapping = standardQuadTree.getSeriaIdMapping(uniqueIdList);
-		standardQuadTree.decidePartitionSerialId(serialIdMapping);
-
+		standardQuadTree.assignPartitionIds();
 
 		g.setColor(Color.ORANGE);
 
-		ArrayList<QuadRectangle> matchedPartitions = new ArrayList<QuadRectangle>();
-		standardQuadTree.getZone(matchedPartitions,quadRectangle);
+		List<QuadRectangle> matchedPartitions = standardQuadTree.findZones(quadRectangle);
 		for(QuadRectangle q:matchedPartitions)
 		{
 			g.drawRect((int)q.x,(int)q.y,(int)q.width,(int)q.height);
 			System.out.println(q.partitionId);
 		}
 	}
-
-
 }


### PR DESCRIPTION
To simplify usage of the StandardQuadTree, combined getAllLeafNodeUniqueId, getSeriaIdMapping, and decidePartitionSerialId into single assignPartitionIds method. Consolidated tree traversal logic within the StandardQuadTree using visitor pattern. Changed global max-items-per-node and max-levels configuration to per-instance. 