### PR TITLE
Do not scan RDD multiple times to get a sample of the data for partitioning

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/utils/RDDSampleUtils.java
+++ b/core/src/main/java/org/datasyslab/geospark/utils/RDDSampleUtils.java
@@ -15,47 +15,42 @@ public class RDDSampleUtils {
    
     
     /**
-     * Gets the sample numbers.
+     * Returns the number of samples to take to partition the RDD into specified number of partitions.
+	 *
+	 * Number of partitions cannot exceed half the number of records in the RDD.
+	 *
+	 * Returns total number of records if it is < 1000. Otherwise, returns 1% of the total number
+	 * of records or twice the number of partitions whichever is larger. Never returns a
+	 * number > Integer.MAX_VALUE.
+	 *
+	 * If desired number of samples is not -1, returns that number.
      *
      * @param numPartitions the num partitions
      * @param totalNumberOfRecords the total number of records
      * @param givenSampleNumbers the given sample numbers
      * @return the sample numbers
-     * @throws Exception the exception
+     * @throws IllegalArgumentException if requested number of samples exceeds total number of records
+	 * 	or if requested number of partitions exceeds half of total number of records
      */
-    public static int getSampleNumbers(Integer numPartitions, long totalNumberOfRecords, long givenSampleNumbers) throws Exception{
-    	Long sampleNumber = new Long(0);
-
-    	if(givenSampleNumbers>0)
+    public static int getSampleNumbers(int numPartitions, long totalNumberOfRecords, int givenSampleNumbers) {
+    	if(givenSampleNumbers > 0)
     	{
-    		// This means that the user manually specifies the sample number
-    		sampleNumber = givenSampleNumbers;
-    		return sampleNumber.intValue();
-    	}
-    	else
-    	{
-    		// Follow GeoSpark internal sampling rule
-        	/*
-        	 * If the input RDD is too small, Geospark will use the entire RDD instead of taking samples.
-        	 */
-        	if(totalNumberOfRecords>=1000)
-        	{
-        		sampleNumber = totalNumberOfRecords / 100;
-        	}
-        	else
-        	{
-        		sampleNumber = totalNumberOfRecords;
-        	}
-        	
-    		if(sampleNumber > Integer.MAX_VALUE) {
-    			sampleNumber = new Long(Integer.MAX_VALUE);
-    		}
-            if(sampleNumber < 2*numPartitions ) {
-                // Partition size is too big. Should throw exception for this.
-                throw new Exception("[RDDSampleUtils][getSampleNumbers] Too many RDD partitions. Call SpatialRDD.setSampleNumber() to manually increase sample or make partitionNum less than "+sampleNumber/2);
-            }
-            return sampleNumber.intValue();
+    		if (givenSampleNumbers > totalNumberOfRecords) {
+    			throw new IllegalArgumentException("Number of samples cannot be larger than total number of records.");
+			}
+    		return givenSampleNumbers;
     	}
 
+    	// Make sure that number of records >= 2 * number of partitions
+		if (totalNumberOfRecords < 2 * numPartitions) {
+    		throw new IllegalArgumentException("Number of partitions cannot be larger than half of total number of records.");
+		}
+
+		if (totalNumberOfRecords < 1000) {
+			return (int) totalNumberOfRecords;
+		}
+
+		final int minSampleCnt = numPartitions * 2;
+    	return (int) Math.max(minSampleCnt, Math.min(totalNumberOfRecords / 100, Integer.MAX_VALUE));
 	}
 }

--- a/core/src/test/java/org/datasyslab/geospark/utils/RDDSampleUtilsTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/utils/RDDSampleUtilsTest.java
@@ -6,29 +6,21 @@
  */
 package org.datasyslab.geospark.utils;
 
-import static org.junit.Assert.assertEquals;
-
-/**
- * 
- * @author Arizona State University DataSystems Lab
- *
- */
-
 import org.junit.Test;
 
-// TODO: Auto-generated Javadoc
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 /**
- * The Class RDDSampleUtilsTest.
+ * @author Arizona State University DataSystems Lab
  */
 public class RDDSampleUtilsTest {
 
     /**
      * Test get sample numbers.
-     *
-     * @throws Exception the exception
      */
     @Test
-    public void testGetSampleNumbers() throws Exception {
+    public void testGetSampleNumbers() {
         assertEquals(10, RDDSampleUtils.getSampleNumbers(2, 10,-1));
         assertEquals(100, RDDSampleUtils.getSampleNumbers(2, 100,-1));
         assertEquals(10, RDDSampleUtils.getSampleNumbers(5, 1000,-1));
@@ -36,18 +28,31 @@ public class RDDSampleUtilsTest {
         assertEquals(100, RDDSampleUtils.getSampleNumbers(5, 10001,-1));
         assertEquals(1000, RDDSampleUtils.getSampleNumbers(5, 100011,-1));
         assertEquals(99, RDDSampleUtils.getSampleNumbers(6, 100011,99));
+        assertEquals(999, RDDSampleUtils.getSampleNumbers(20, 999,-1));
+        assertEquals(40, RDDSampleUtils.getSampleNumbers(20, 1000,-1));
     }
     
     /**
      * Test too many partitions.
-     *
-     * @throws Exception the exception
      */
-    @Test(expected=Exception.class)
-    public void testTooManyPartitions() throws Exception
+    @Test
+    public void testTooManyPartitions()
     {
-        assertEquals(10, RDDSampleUtils.getSampleNumbers(6, 1010,-1));
-        assertEquals(11, RDDSampleUtils.getSampleNumbers(6, 1110,-1));
-        assertEquals(100, RDDSampleUtils.getSampleNumbers(100, 10000,-1));
+        assertFailure(505, 999);
+        assertFailure(505, 1000);
+        assertFailure(10, 1000, 2100);
+    }
+
+    private void assertFailure(int numPartitions, long totalNumberOfRecords) {
+        assertFailure(numPartitions, totalNumberOfRecords, -1);
+    }
+
+    private void assertFailure(int numPartitions, long totalNumberOfRecords, int givenSampleNumber) {
+        try {
+            RDDSampleUtils.getSampleNumbers(numPartitions, totalNumberOfRecords, givenSampleNumber);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }


### PR DESCRIPTION
SpatialRDD.spatialPartitioning(GridType gridType) method uses RDD.takeSample API to sample the data and build partitioning grid. RDD.takeSample API tends to scan RDD multiple times to get the exact number of requested samples. For large datasets, the extra latency is significant. Since it is not critical to get the exact number of samples, this PR starts to use RDD.sample API.

See https://github.com/apache/spark/blob/412b0e8969215411b97efd3d0984dc6cac5d31e0/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L508

Also, fixed confusing behavior of RDDSampleUtils where it would allow to partition an RDD of 999 records into up to 499 partitions, but not allow the same for RDD of 1000 records. 

Updated RDDSampleUtilsTest.testTooManyPartitions to actually test 3 different scenarios instead of testing first scenario only.