### PR TITLE
Collect envelopes instead of full geometry objects when sampling

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
@@ -7,7 +7,6 @@
 package org.datasyslab.geospark.spatialPartitioning;
 
 import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
 import org.datasyslab.geospark.spatialPartitioning.quadtree.QuadRectangle;
 import org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree;
 
@@ -28,11 +27,11 @@ public class QuadtreePartitioning implements Serializable {
      * @param boundary   the boundary
      * @param partitions the partitions
      */
-    public QuadtreePartitioning(List<? extends Geometry> samples, Envelope boundary, int partitions) throws Exception {
+    public QuadtreePartitioning(List<Envelope> samples, Envelope boundary, int partitions) throws Exception {
         this(samples, boundary, partitions, -1);
     }
 
-    public QuadtreePartitioning(List<? extends Geometry> samples, Envelope boundary, final int partitions, int minTreeLevel)
+    public QuadtreePartitioning(List<Envelope> samples, Envelope boundary, final int partitions, int minTreeLevel)
             throws Exception {
         partitionTree = new StandardQuadTree(new QuadRectangle(boundary), 0,
             samples.size() / partitions, 100000);
@@ -40,9 +39,8 @@ public class QuadtreePartitioning implements Serializable {
             partitionTree.forceGrowUp(minTreeLevel);
         }
 
-        for (final Geometry sample : samples) {
-            final Envelope envelope = sample.getEnvelopeInternal();
-            partitionTree.insert(new QuadRectangle(envelope), 1);
+        for (final Envelope sample : samples) {
+            partitionTree.insert(new QuadRectangle(sample), 1);
         }
 
         partitionTree.assignPartitionIds();

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/RtreePartitioning.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/RtreePartitioning.java
@@ -6,14 +6,12 @@
  */
 package org.datasyslab.geospark.spatialPartitioning;
 
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.index.strtree.STRtree;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
-
-import com.vividsolutions.jts.index.strtree.STRtree;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -22,43 +20,28 @@ import com.vividsolutions.jts.index.strtree.STRtree;
 public class RtreePartitioning implements Serializable{
 
 	/** The grids. */
-	List<Envelope> grids=new ArrayList<Envelope>();
+	final List<Envelope> grids = new ArrayList<>();
 	
 	
 	/**
 	 * Instantiates a new rtree partitioning.
 	 *
-	 * @param SampleList the sample list
+	 * @param samples the sample list
 	 * @param boundary the boundary
 	 * @param partitions the partitions
 	 * @throws Exception the exception
 	 */
-	public RtreePartitioning(List SampleList,Envelope boundary,int partitions) throws Exception
+	public RtreePartitioning(List<Envelope> samples, Envelope boundary, int partitions) throws Exception
 	{
-		STRtree strtree=new STRtree(SampleList.size()/partitions);
-    	for(int i=0;i<SampleList.size();i++)
-    	{
-    		if(SampleList.get(i) instanceof Envelope)
-    		{
-    			Envelope spatialObject = (Envelope)SampleList.get(i);
-    			strtree.insert(spatialObject, spatialObject);
-    		}
-    		else if(SampleList.get(i) instanceof Geometry)
-    		{
-    			Geometry spatialObject = (Geometry)SampleList.get(i);
-    			strtree.insert(spatialObject.getEnvelopeInternal(), spatialObject);
-    		}
-    		else
-    		{
-    			throw new Exception("[RtreePartitioning][Constrcutor] Unsupported spatial object type");
-    		}
+		STRtree strtree=new STRtree(samples.size()/partitions);
+		for (Envelope sample : samples) {
+			strtree.insert(sample, sample);
     	}
+
     	List<Envelope> envelopes=strtree.queryBoundary();
-    	for(int i=0;i<envelopes.size();i++)
-    	{
-    		grids.add(envelopes.get(i));
+		for (Envelope envelope : envelopes) {
+    		grids.add(envelope);
     	}
-    	//grids.add(new EnvelopeWithGrid(boundary,grids.size()));
 	}
 	
 	/**

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/VoronoiPartitioning.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/VoronoiPartitioning.java
@@ -6,10 +6,6 @@
  */
 package org.datasyslab.geospark.spatialPartitioning;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
@@ -18,6 +14,10 @@ import com.vividsolutions.jts.geom.MultiPoint;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.triangulate.VoronoiDiagramBuilder;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -31,40 +31,25 @@ public class VoronoiPartitioning implements Serializable{
 	/**
 	 * Instantiates a new voronoi partitioning.
 	 *
-	 * @param SampleList the sample list
+	 * @param samples the sample list
 	 * @param boundary the boundary
 	 * @param partitions the partitions
 	 * @throws Exception the exception
 	 */
-	public VoronoiPartitioning(List SampleList,Envelope boundary,int partitions) throws Exception
+	public VoronoiPartitioning(List<Envelope> samples, Envelope boundary, int partitions) throws Exception
 	{
 		GeometryFactory fact = new GeometryFactory();
 		ArrayList<Point> subSampleList=new ArrayList<Point>();
 		MultiPoint mp;
 		
 		//Take a subsample accoring to the partitions
-		if(SampleList.get(0) instanceof Envelope)
+		for(int i=0;i<samples.size();i=i+samples.size()/partitions)
 		{
-			for(int i=0;i<SampleList.size();i=i+SampleList.size()/partitions)
-			{
-				Envelope envelope=(Envelope)SampleList.get(i);
-				Coordinate coordinate = new Coordinate((envelope.getMinX()+envelope.getMaxX())/2.0,(envelope.getMinY()+envelope.getMaxY())/2.0);
-				subSampleList.add(fact.createPoint(coordinate));
-			}
+			Envelope envelope = samples.get(i);
+			Coordinate coordinate = new Coordinate((envelope.getMinX()+envelope.getMaxX())/2.0,(envelope.getMinY()+envelope.getMaxY())/2.0);
+			subSampleList.add(fact.createPoint(coordinate));
 		}
-		else if(SampleList.get(0) instanceof Geometry)
-		{
-			for(int i=0;i<SampleList.size();i=i+SampleList.size()/partitions)
-			{
-				Envelope envelope=((Geometry)SampleList.get(i)).getEnvelopeInternal();
-				Coordinate coordinate = new Coordinate((envelope.getMinX()+envelope.getMaxX())/2.0,(envelope.getMinY()+envelope.getMaxY())/2.0);
-				subSampleList.add(fact.createPoint(coordinate));
-			}
-		}
-		else
-		{
-	    	throw new Exception("[VoronoiPartitioning][Constrcutor] Unsupported spatial object type");
-		}
+
 		mp=fact.createMultiPoint(subSampleList.toArray(new Point[subSampleList.size()]));
 		VoronoiDiagramBuilder voronoiBuilder = new VoronoiDiagramBuilder();
 		voronoiBuilder.setSites(mp);


### PR DESCRIPTION
Spatial partitioning involves sampling and building partitioning scheme from the samples. Building of partitioning scheme happens in the driver and therefore requires samples to be transferred from the cluster to the driver machine. Each sample contains a geometry object and user data. Both, geometry object and user data can be large. In particular, complex polygons may contain lots of vertexes and holes and therefore be expensive to transfer other the network. Since partitioning building schemes use only bounding boxes of the samples, we can avoid transferring large geometries and user data to the driver by transforming samples into bounding boxes before collecting them to the driver. The PR updates SpatialRDD to do that and updates *Partitioning class to remove no longer needed logic of converting Geometry objects to bounding boxes.

This PR is built on top of two other PRs:

https://github.com/DataSystemsLab/GeoSpark/pull/126
https://github.com/DataSystemsLab/GeoSpark/pull/127