### PR TITLE
 Start collecting metrics about spatial join execution

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,7 +69,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.datasyslab</groupId>
             <artifactId>sernetcdf</artifactId>
@@ -171,8 +170,23 @@
                 <version>3.2.1</version>
                 <executions>
                     <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
+                            <goal>add-source</goal>
                             <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <arg>-dependencyfile</arg>
+                                <arg>${project.build.directory}/.scala_dependencies</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>

--- a/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkListener.scala
+++ b/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkListener.scala
@@ -1,0 +1,66 @@
+package org.datasyslab.geospark.monitoring
+
+import org.apache.spark.scheduler.{AccumulableInfo, SparkListener, SparkListenerStageCompleted, SparkListenerTaskEnd}
+
+import scala.collection.mutable
+
+class GeoSparkListener extends SparkListener {
+
+  private val counterNames = Seq("buildCount", "streamCount", "candidateCount", "resultCount")
+
+  private val taskCpuTime: mutable.Map[(Integer, Integer), Long] = mutable.Map()
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+    if (taskEnd.reason == org.apache.spark.Success) {
+      val cpuTime = taskEnd.taskMetrics.executorCpuTime
+      // Task ID is a string made of two integers separated with period:
+      //  <partition-id>.<attempt-id>
+      val partitionId = Integer.parseInt(taskEnd.taskInfo.id.split('.')(0))
+
+      taskCpuTime((taskEnd.stageId, partitionId)) = cpuTime
+    }
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) = {
+    val accumulables = stageCompleted.stageInfo.accumulables
+
+    def getCounterOption(name: String) = {
+      accumulables.find { case (k, v) => v.name == Some("geospark.spatialjoin." + name) }
+    }
+
+    def getCounter(name: String) = {
+      getCounterOption(name).get._2.value.get
+    }
+
+    if (getCounterOption("buildCount").isDefined) {
+
+      val stageId = stageCompleted.stageInfo.stageId
+
+      val buildCounts: Map[Int, Long] = getCounter("buildCount").asInstanceOf[Map[Int, Long]]
+      val streamCounts: Map[Int, Long] = getCounter("streamCount").asInstanceOf[Map[Int, Long]]
+      val candidateCounts: Map[Int, Long] = getCounter("candidateCount").asInstanceOf[Map[Int, Long]]
+      val resultCounts: Map[Int, Long] = getCounter("resultCount").asInstanceOf[Map[Int, Long]]
+
+      val stats: List[(Int, Long, Long, Long, Long, Long)] =
+        buildCounts.map {
+          case (partitionId, buildCount) => {
+            val streamCount: Long = streamCounts.getOrElse(partitionId, -1)
+            val candidateCount: Long = candidateCounts.getOrElse(partitionId, -1)
+            val resultCount: Long = resultCounts.getOrElse(partitionId, -1)
+            val cpuTime: Long = taskCpuTime.getOrElse((stageId, partitionId), -1)
+            (partitionId, buildCount, streamCount, candidateCount, resultCount, cpuTime)
+          }
+        }.toList.sortBy {
+          case (_, _, _, _, _, cpuTime) => cpuTime
+        }
+
+      Console.out.println("Spatial join is complete. Execution statistics:")
+      Console.out.println("Partition\t CPU Time (s)\tBuild ##\tStream ##\tCandidates ##\tResults ##")
+      stats.foreach {
+        case (partitionId, buildCount, streamCount, candidateCount, resultCount, cpuTime) =>
+          Console.out.println(f"$partitionId% 10d\t${cpuTime / 1000}% 10d" +
+            f"$buildCount% 10d\t$streamCount% 10d\t$candidateCount% 10d\t$resultCount% 10d")
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkMetric.scala
+++ b/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkMetric.scala
@@ -1,0 +1,34 @@
+package org.datasyslab.geospark.monitoring
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.util.AccumulatorV2
+
+import scala.collection.mutable
+
+/**
+  * An accumulator to collect custom per-task metrics into a map
+  * keyed by partition ID processed by the task.
+  */
+case class GeoSparkMetric(initialValue: Map[Int, Long] = Map()) extends AccumulatorV2[Long, Map[Int, Long]] {
+  private var _counts: mutable.Map[Int, Long] = mutable.Map[Int, Long]() ++ initialValue
+
+  override def isZero: Boolean = _counts.isEmpty
+
+  override def copy(): AccumulatorV2[Long, Map[Int, Long]] = new GeoSparkMetric(_counts.toMap)
+
+  override def reset(): Unit = _counts.clear()
+
+  override def add(v: Long): Unit = add(TaskContext.getPartitionId, v)
+
+  private def add(partitionId: Int, value: Long) = {
+    _counts(partitionId) = value + _counts.getOrElse(partitionId, 0L)
+  }
+
+  override def merge(other: AccumulatorV2[Long, Map[Int, Long]]): Unit = {
+    other.asInstanceOf[GeoSparkMetric]._counts.foreach {
+      case (partitionId, value) => add(partitionId, value)
+    }
+  }
+
+  override def value: Map[Int, Long] = _counts.toMap
+}

--- a/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkMetrics.scala
+++ b/core/src/main/scala/org/datasyslab/geospark/monitoring/GeoSparkMetrics.scala
@@ -1,0 +1,11 @@
+package org.datasyslab.geospark.monitoring
+
+import org.apache.spark.SparkContext
+
+object GeoSparkMetrics {
+  def createMetric(sc: SparkContext, name: String): GeoSparkMetric = {
+    val acc = new GeoSparkMetric()
+    sc.register(acc, "geospark.spatialjoin." + name)
+    acc
+  }
+}

--- a/core/src/test/scala/org/datasyslab/geospark/monitoring/GeoSparkMetricSuite.scala
+++ b/core/src/test/scala/org/datasyslab/geospark/monitoring/GeoSparkMetricSuite.scala
@@ -1,0 +1,46 @@
+package org.datasyslab.geospark.monitoring
+
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.{SparkConf, SparkContext, TaskContext}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, FunSuiteLike}
+
+class GeoSparkMetricSuite extends FunSuite with FunSuiteLike with BeforeAndAfterAll {
+
+  implicit lazy val sc = {
+    val conf = new SparkConf().setAppName(classOf[GeoSparkMetricSuite].getName).setMaster("local[2]")
+    val sc = new SparkContext(conf)
+    Logger.getLogger("org").setLevel(Level.WARN)
+    Logger.getLogger("akka").setLevel(Level.WARN)
+    sc
+  }
+
+  override def afterAll(): Unit = {
+    sc.stop
+  }
+
+  test("simple count") {
+
+    val data = 1 to 100
+    val rdd = sc.parallelize(data, 5)
+
+    val metric = GeoSparkMetrics.createMetric(sc, "count")
+
+    // Count elements in each partition. For partitions with even IDs count each element twice.
+    rdd.map { x =>
+      if (TaskContext.getPartitionId() % 2 == 0)
+        metric.add(2)
+      else
+        metric.add(1)
+      x
+    }.collect
+
+    // Verify metric
+    val expectedPartitionIds = 0 to 4
+    assert(expectedPartitionIds == metric.value.keys.toSeq.sorted)
+
+    for ((partitionId, count) <- metric.value) {
+      val expectedCount = if (partitionId % 2 == 0) 40 else 20
+      assert(count == expectedCount)
+    }
+  }
+}


### PR DESCRIPTION
Partitioning the data into roughly same-size buckets is critical for spatial join performance. Spatial join is a lot less performant when there is a skew. This PR introduces a set of metrics to help investigate skew.

Introduced GeoSparkMetric accumulator to collect per-task metrics and updated DynamicIndexLookupJudgement to collect the following statistics for individual partitions:

- number of objects on the build side of the join;
- number of objects on the streaming side of the join;
- number of candidate object pairs (bounding boxes intersect);
- number of join results

Added GeoSparkListener to print out new statistics at the end of the join.