### PR TITLE
Fix java.lang.StackOverflowError in StandardQuadTree.insert

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/QuadtreePartitioning.java
@@ -33,8 +33,11 @@ public class QuadtreePartitioning implements Serializable {
 
     public QuadtreePartitioning(List<Envelope> samples, Envelope boundary, final int partitions, int minTreeLevel)
             throws Exception {
+        // Make sure the tree doesn't get too deep in case of data skew
+        int maxLevel = partitions;
+        int maxItemsPerNode = samples.size() / partitions;
         partitionTree = new StandardQuadTree(new QuadRectangle(boundary), 0,
-            samples.size() / partitions, 100000);
+            maxItemsPerNode, maxLevel);
         if (minTreeLevel > 0) {
             partitionTree.forceGrowUp(minTreeLevel);
         }

--- a/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadTreePartitioningTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialPartitioning/quadtree/QuadTreePartitioningTest.java
@@ -1,0 +1,40 @@
+package org.datasyslab.geospark.spatialPartitioning.quadtree;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import org.datasyslab.geospark.spatialPartitioning.QuadtreePartitioning;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuadTreePartitioningTest {
+
+    private final GeometryFactory factory = new GeometryFactory();
+
+    /**
+     * Verifies that data skew doesn't cause java.lang.StackOverflowError
+     * in StandardQuadTree.insert
+     */
+    @Test
+    public void testDataSkew() throws Exception {
+
+        // Create an artificially skewed data set of identical envelopes
+        final Point point = factory.createPoint(new Coordinate(0, 0));
+
+        final List<Envelope> samples = new ArrayList<>();
+        for (int i=0; i<1000; i++) {
+            samples.add(point.getEnvelopeInternal());
+        }
+
+        final Envelope extent = new Envelope(0, 1, 0, 1);
+
+        // Make sure Quad-tree is built successfully without throwing
+        // java.lang.StackOverflowError
+        QuadtreePartitioning partitioning = new QuadtreePartitioning(samples, extent, 10);
+        Assert.assertNotNull(partitioning.getPartitionTree());
+    }
+}


### PR DESCRIPTION
StandardQuadTree.insert could get into an infinite split cycle if there was a lot of data in the corner of the overall extent. This PR puts a cap on the depth of the tree equal to the number of desired partitions to avoid the problem.

java.lang.StackOverflowError
  at org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree.findRegion(StandardQuadTree.java:62)
  at org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree.insert(StandardQuadTree.java:153)
  at org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree.insert(StandardQuadTree.java:159)
  at org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree.insert(StandardQuadTree.java:169)
  at org.datasyslab.geospark.spatialPartitioning.quadtree.StandardQuadTree.insert(StandardQuadTree.java:159)