### PR TITLE
Add support for .shx file for extracting .shp file

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShpFileParser.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShpFileParser.java
@@ -69,7 +69,7 @@ public class ShpFileParser implements Serializable, ShapeFileConst{
     {
         reader.skip(INT_LENGTH);
         reader.skip(HEAD_EMPTY_NUM * INT_LENGTH);
-        fileLength = 16 * (reader.readInt() - HEAD_FILE_LENGTH_16BIT);
+        fileLength = 2 * ((long)reader.readInt() - HEAD_FILE_LENGTH_16BIT);
         remainLength = fileLength;
         // Skip 2 integers: file version and token type
         reader.skip(2 * INT_LENGTH);
@@ -85,7 +85,7 @@ public class ShpFileParser implements Serializable, ShapeFileConst{
     public ShpRecord parseRecordPrimitiveContent() throws IOException{
         // get length of record content
         int contentLength = reader.readInt();
-        long recordLength = 16 * (contentLength + 4);
+        long recordLength = 2 * (contentLength + 4);
         remainLength -= recordLength;
         int typeID = EndianUtils.swapInteger(reader.readInt());
         byte[] contentArray = new byte[contentLength * 2 - INT_LENGTH];// exclude the 4 bytes we read for shape type
@@ -101,7 +101,7 @@ public class ShpFileParser implements Serializable, ShapeFileConst{
     public ShpRecord parseRecordPrimitiveContent(int length) throws IOException{
         // get length of record content
         int contentLength = reader.readInt();
-        long recordLength = 16 * (contentLength + 4);
+        long recordLength = 2 * (contentLength + 4);
         remainLength -= recordLength;
         int typeID = EndianUtils.swapInteger(reader.readInt());
         byte[] contentArray = new byte[length];// exclude the 4 bytes we read for shape type

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShpFileParser.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShpFileParser.java
@@ -94,6 +94,22 @@ public class ShpFileParser implements Serializable, ShapeFileConst{
     }
 
     /**
+     * abstract information from record header and then copy primitive bytes data of record to a primitive record.
+     * @return
+     * @throws IOException
+     */
+    public ShpRecord parseRecordPrimitiveContent(int length) throws IOException{
+        // get length of record content
+        int contentLength = reader.readInt();
+        long recordLength = 16 * (contentLength + 4);
+        remainLength -= recordLength;
+        int typeID = EndianUtils.swapInteger(reader.readInt());
+        byte[] contentArray = new byte[length];// exclude the 4 bytes we read for shape type
+        reader.read(contentArray,0,contentArray.length);
+        return new ShpRecord(contentArray, typeID);
+    }
+
+    /**
      * abstract id number from record header
      * @return
      * @throws IOException

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
@@ -86,7 +86,7 @@ public class ShapeFileReader extends RecordReader<ShapeKey, ShpRecord> {
             indexId += 2;
             return true;
         }else{
-            if(getProgress() >= 2) return false;
+            if(getProgress() >= 1) return false;
             recordKey = new ShapeKey();
             recordKey.setIndex(parser.parseRecordHeadID());
             recordContent = parser.parseRecordPrimitiveContent();

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
@@ -16,6 +16,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp.ShpFileParser;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
 
 public class ShapeFileReader extends RecordReader<ShapeKey, ShpRecord> {
 
@@ -31,6 +33,30 @@ public class ShapeFileReader extends RecordReader<ShapeKey, ShpRecord> {
     /** file parser */
     ShpFileParser parser = null;
 
+    /** Iterator of indexes of records */
+    private int[] indexes;
+
+    /** whether use index, true when using indexes */
+    private boolean useIndex = false;
+
+    /** current index id */
+    private int indexId = 0;
+
+    /**
+     * empty constructor
+     */
+    public ShapeFileReader() {
+    }
+
+    /**
+     * constructor with index
+     * @param indexes
+     */
+    public ShapeFileReader(int[] indexes) {
+        this.indexes = indexes;
+        useIndex = true;
+    }
+
     public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
         FileSplit fileSplit = (FileSplit)split;
         Path filePath = fileSplit.getPath();
@@ -41,12 +67,24 @@ public class ShapeFileReader extends RecordReader<ShapeKey, ShpRecord> {
         parser.parseShapeFileHead();
     }
 
+
+
     public boolean nextKeyValue() throws IOException, InterruptedException {
-        if(getProgress() >= 1) return false;
-        recordKey = new ShapeKey();
-        recordKey.setIndex(parser.parseRecordHeadID());
-        recordContent = parser.parseRecordPrimitiveContent();
-        return true;
+        if(useIndex){// with index, try first
+            if((indexId + 1) * 2 == indexes.length) return false;
+            int currentLength = indexes[indexId * 2 + 1] * 2 - 4;
+            recordKey = new ShapeKey();
+            recordKey.setIndex(parser.parseRecordHeadID());
+            recordContent = parser.parseRecordPrimitiveContent(currentLength);
+            indexId++;
+            return true;
+        }else{
+            if(getProgress() >= 2) return false;
+            recordKey = new ShapeKey();
+            recordKey.setIndex(parser.parseRecordHeadID());
+            recordContent = parser.parseRecordPrimitiveContent();
+            return true;
+        }
     }
 
     public ShapeKey getCurrentKey() throws IOException, InterruptedException {

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapeFileReader.java
@@ -70,13 +70,20 @@ public class ShapeFileReader extends RecordReader<ShapeKey, ShpRecord> {
 
 
     public boolean nextKeyValue() throws IOException, InterruptedException {
-        if(useIndex){// with index, try first
-            if((indexId + 1) * 2 == indexes.length) return false;
-            int currentLength = indexes[indexId * 2 + 1] * 2 - 4;
+        if(useIndex){
+            /**
+             * with index, iterate until end and extract bytes with information from indexes
+             */
+            if(indexId == indexes.length) return false;
+            // check offset, if current offset in inputStream not match with information in shx, move it
+            if(shpInputStream.getPos() < indexes[indexId] * 2){
+                shpInputStream.skip(indexes[indexId] * 2 - shpInputStream.getPos());
+            }
+            int currentLength = indexes[indexId + 1] * 2 - 4;
             recordKey = new ShapeKey();
             recordKey.setIndex(parser.parseRecordHeadID());
             recordContent = parser.parseRecordPrimitiveContent(currentLength);
-            indexId++;
+            indexId += 2;
             return true;
         }else{
             if(getProgress() >= 2) return false;

--- a/core/src/test/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
@@ -55,7 +55,7 @@ public class ShapefileReaderTest implements Serializable{
 
     @BeforeClass
     public static void onceExecutedBeforeAll() {
-        SparkConf conf = new SparkConf().setAppName("ShapefileRDDTest").setMaster("local[2]").set("spark.executor.cores","2");
+        SparkConf conf = new SparkConf().setAppName("ShapefileRDDTest").setMaster("local[2]").set("spark.executor.cores","2").set("spark.executor.memory", "4g");
         sc = new JavaSparkContext(conf);
         Logger.getLogger("org").setLevel(Level.WARN);
         Logger.getLogger("akka").setLevel(Level.WARN);
@@ -269,6 +269,21 @@ public class ShapefileReaderTest implements Serializable{
             .getFeatureSource(typeName);
         Filter filter = Filter.INCLUDE;
         return source.getFeatures(filter);
+    }
+
+    /**
+     * Test correctness of parsing shapefile
+     * @throws IOException
+     */
+    @Test
+    public void testShxFile() throws IOException {
+        // load shape with geotool.shapefile
+        String inputLocation = "/Users/zongsizhang/Downloads/water-polygons-split-4326";
+        //FeatureCollection<SimpleFeatureType, SimpleFeature> collection = loadFeatures(inputLocation);
+        // load shapes with our tool
+        JavaRDD<Geometry> shapeRDD = ShapefileReader.readToGeometryRDD(sc, inputLocation);
+        System.out.println(shapeRDD.count());
+        //Assert.assertEquals(shapeRDD.collect().size(), collection.size());
     }
 
     @AfterClass

--- a/core/src/test/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
@@ -266,24 +266,9 @@ public class ShapefileReaderTest implements Serializable{
         DataStore dataStore = DataStoreFinder.getDataStore(map);
         String typeName = dataStore.getTypeNames()[0];
         FeatureSource<SimpleFeatureType, SimpleFeature> source = dataStore
-            .getFeatureSource(typeName);
+                .getFeatureSource(typeName);
         Filter filter = Filter.INCLUDE;
         return source.getFeatures(filter);
-    }
-
-    /**
-     * Test correctness of parsing shapefile
-     * @throws IOException
-     */
-    @Test
-    public void testShxFile() throws IOException {
-        // load shape with geotool.shapefile
-        String inputLocation = "/Users/zongsizhang/Downloads/water-polygons-split-4326";
-        //FeatureCollection<SimpleFeatureType, SimpleFeature> collection = loadFeatures(inputLocation);
-        // load shapes with our tool
-        JavaRDD<Geometry> shapeRDD = ShapefileReader.readToGeometryRDD(sc, inputLocation);
-        System.out.println(shapeRDD.count());
-        //Assert.assertEquals(shapeRDD.collect().size(), collection.size());
     }
 
     @AfterClass


### PR DESCRIPTION
In this PR I complete the logic of reading .shx file and extracting bytes from .shp file with indexes. This update can fix missing shapes when reading .shp files with incorrect file length in .shp file.