### PR TITLE
Introduce 2-D-B-tree partitioning scheme

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/enums/GridType.java
+++ b/core/src/main/java/org/datasyslab/geospark/enums/GridType.java
@@ -37,7 +37,13 @@ public enum GridType implements Serializable {
 	/**
 	 * The voronoi.
 	 */
-	QUADTREE;
+	QUADTREE,
+
+	/**
+	 * K-D-B-tree (k-dimensional B-tree)
+	 */
+	KDBTREE;
+
 	/**
 	 * Gets the grid type.
 	 *

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/KDBTree.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/KDBTree.java
@@ -1,0 +1,267 @@
+package org.datasyslab.geospark.spatialPartitioning;
+
+
+import com.vividsolutions.jts.geom.Envelope;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * see https://en.wikipedia.org/wiki/K-D-B-tree
+ */
+public class KDBTree implements Serializable {
+
+    private final int maxItemsPerNode;
+    private final int maxLevels;
+    private final Envelope extent;
+    private final int level;
+    private final List<Envelope> items = new ArrayList<>();
+    private KDBTree[] children;
+    private int leafId = 0;
+
+    public KDBTree(int maxItemsPerNode, int maxLevels, Envelope extent) {
+        this(maxItemsPerNode, maxLevels, 0, extent);
+    }
+
+    private KDBTree(int maxItemsPerNode, int maxLevels, int level, Envelope extent) {
+        this.maxItemsPerNode = maxItemsPerNode;
+        this.maxLevels = maxLevels;
+        this.level = level;
+        this.extent = extent;
+    }
+
+    public int getItemCount() {
+        return items.size();
+    }
+
+    public boolean isLeaf() {
+        return children == null;
+    }
+
+    public int getLeafId() {
+        if (!isLeaf()) {
+            throw new IllegalStateException();
+        }
+
+        return leafId;
+    }
+
+    public Envelope getExtent() {
+        return extent;
+    }
+
+    public void insert(Envelope envelope) {
+        if (items.size() < maxItemsPerNode || level >= maxLevels) {
+            items.add(envelope);
+        } else {
+            if (children == null) {
+                // Split over longer side
+                boolean splitX = extent.getWidth() > extent.getHeight();
+                boolean ok = split(splitX);
+                if (!ok) {
+                    // Try spitting by the other side
+                    ok = split(!splitX);
+                }
+
+                if (!ok) {
+                    // This could happen if all envelopes are the same.
+                    items.add(envelope);
+                    return;
+                }
+            }
+
+            for (KDBTree child : children) {
+                if (child.extent.contains(envelope.getMinX(), envelope.getMinY())) {
+                    child.insert(envelope);
+                    break;
+                }
+            }
+        }
+    }
+
+    public void dropElements() {
+        traverse(new Visitor() {
+            @Override
+            public boolean visit(KDBTree tree) {
+                tree.items.clear();
+                return true;
+            }
+        });
+    }
+
+    public List<KDBTree> findLeafNodes(final Envelope envelope) {
+        final List<KDBTree> matches = new ArrayList<>();
+        traverse(new Visitor() {
+            @Override
+            public boolean visit(KDBTree tree) {
+                if (!disjoint(tree.getExtent(), envelope)) {
+                    if (tree.isLeaf()) {
+                        matches.add(tree);
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        });
+
+        return matches;
+    }
+
+    private boolean disjoint(Envelope r1, Envelope r2) {
+        return !r1.intersects(r2) && !r1.covers(r2) && !r2.covers(r1);
+    }
+
+    public interface Visitor {
+        /**
+         * Visits a single node of the tree
+         * @param tree Node to visit
+         * @return true to continue traversing the tree; false to stop
+         */
+        boolean visit(KDBTree tree);
+    }
+
+    /**
+     * Traverses the tree top-down breadth-first and calls the visitor
+     * for each node. Stops traversing if a call to Visitor.visit returns false.
+     */
+    public void traverse(Visitor visitor) {
+        if (!visitor.visit(this)) {
+            return;
+        }
+
+        if (children != null) {
+            for (KDBTree child : children) {
+                child.traverse(visitor);
+            }
+        }
+    }
+
+    public void assignLeafIds() {
+        traverse(new Visitor() {
+            int id = 0;
+
+            @Override
+            public boolean visit(KDBTree tree) {
+                if (tree.isLeaf()) {
+                    tree.leafId = id;
+                    id++;
+                }
+                return true;
+            }
+        });
+    }
+
+    private boolean split(boolean splitX) {
+        final Comparator<Envelope> comparator = splitX ? new XComparator() : new YComparator();
+        Collections.sort(items, comparator);
+
+        final Envelope[] splits;
+        final Splitter splitter;
+        Envelope middleItem = items.get((int) Math.floor(items.size() / 2));
+        if (splitX) {
+            double x = middleItem.getMinX();
+            if (x > extent.getMinX() && x < extent.getMaxX()) {
+                splits = splitAtX(extent, x);
+                splitter = new XSplitter(x);
+            } else {
+                // Too many objects are crowded at the edge of the extent. Can't split.
+                return false;
+            }
+        } else {
+            double y = middleItem.getMinY();
+            if (y > extent.getMinY() && y < extent.getMaxY()) {
+                splits = splitAtY(extent, y);
+                splitter = new YSplitter(y);
+            } else {
+                // Too many objects are crowded at the edge of the extent. Can't split.
+                return false;
+            }
+        }
+
+        children = new KDBTree[2];
+        children[0] = new KDBTree(maxItemsPerNode, maxLevels, level + 1, splits[0]);
+        children[1] = new KDBTree(maxItemsPerNode, maxLevels, level + 1, splits[1]);
+
+        // Move items
+        splitItems(splitter);
+        return true;
+    }
+
+    private static final class XComparator implements Comparator<Envelope> {
+        @Override
+        public int compare(Envelope o1, Envelope o2) {
+            double deltaX = o1.getMinX() - o2.getMinX();
+            return (int) Math.signum(deltaX != 0 ? deltaX : o1.getMinY() - o2.getMinY());
+        }
+    }
+
+    private static final class YComparator implements Comparator<Envelope> {
+        @Override
+        public int compare(Envelope o1, Envelope o2) {
+            double deltaY = o1.getMinY() - o2.getMinY();
+            return (int) Math.signum(deltaY != 0 ? deltaY : o1.getMinX() - o2.getMinX());
+        }
+    }
+
+    private interface Splitter
+    {
+        /**
+         * @return true if the specified envelope belongs to the lower split
+         */
+        boolean split(Envelope envelope);
+    }
+
+    private static final class XSplitter implements Splitter {
+        private final double x;
+
+        private XSplitter(double x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean split(Envelope envelope) {
+            return envelope.getMinX() <= x;
+        }
+    }
+
+    private static final class YSplitter implements Splitter {
+        private final double y;
+
+        private YSplitter(double y) {
+            this.y = y;
+        }
+
+        @Override
+        public boolean split(Envelope envelope) {
+            return envelope.getMinY() <= y;
+        }
+    }
+
+    private void splitItems(Splitter splitter) {
+        for (Envelope item : items) {
+            children[splitter.split(item) ? 0 : 1].insert(item);
+        }
+    }
+
+    private Envelope[] splitAtX(Envelope envelope, double x) {
+        assert(envelope.getMinX() < x);
+        assert(envelope.getMaxX() > x);
+        Envelope[] splits = new Envelope[2];
+        splits[0] = new Envelope(envelope.getMinX(), x, envelope.getMinY(), envelope.getMaxY());
+        splits[1] = new Envelope(x, envelope.getMaxX(), envelope.getMinY(), envelope.getMaxY());
+        return splits;
+    }
+
+    private Envelope[] splitAtY(Envelope envelope, double y) {
+        assert(envelope.getMinY() < y);
+        assert(envelope.getMaxY() > y);
+        Envelope[] splits = new Envelope[2];
+        splits[0] = new Envelope(envelope.getMinX(), envelope.getMaxX(), envelope.getMinY(), y);
+        splits[1] = new Envelope(envelope.getMinX(), envelope.getMaxX(), y, envelope.getMaxY());
+        return splits;
+    }
+}

--- a/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/KDBTreePartitioner.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialPartitioning/KDBTreePartitioner.java
@@ -1,0 +1,78 @@
+package org.datasyslab.geospark.spatialPartitioning;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import org.datasyslab.geospark.enums.GridType;
+import org.datasyslab.geospark.joinJudgement.DedupParams;
+import org.datasyslab.geospark.utils.HalfOpenRectangle;
+import scala.Tuple2;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class KDBTreePartitioner extends SpatialPartitioner {
+    private final KDBTree tree;
+
+    public KDBTreePartitioner(KDBTree tree) {
+        super(GridType.KDBTREE, getLeafZones(tree));
+        this.tree = tree;
+        this.tree.dropElements();
+    }
+
+    @Override
+    public int numPartitions() {
+        return grids.size();
+    }
+
+    @Override
+    public <T extends Geometry> Iterator<Tuple2<Integer, T>> placeObject(T spatialObject)
+        throws Exception {
+
+        Objects.requireNonNull(spatialObject, "spatialObject");
+
+        final Envelope envelope = spatialObject.getEnvelopeInternal();
+
+        final List<KDBTree> matchedPartitions = tree.findLeafNodes(envelope);
+
+        final Point point = spatialObject instanceof Point ? (Point) spatialObject : null;
+
+        final Set<Tuple2<Integer, T>> result = new HashSet<>();
+        for (KDBTree leaf : matchedPartitions) {
+            // For points, make sure to return only one partition
+            if (point != null && !(new HalfOpenRectangle(leaf.getExtent())).contains(point)) {
+                continue;
+            }
+
+            result.add(new Tuple2(leaf.getLeafId(), spatialObject));
+        }
+
+        return result.iterator();
+    }
+
+    @Nullable
+    @Override
+    public DedupParams getDedupParams() {
+        return new DedupParams(grids);
+    }
+
+    private static List<Envelope> getLeafZones(KDBTree tree) {
+        final List<Envelope> leafs = new ArrayList<>();
+        tree.traverse(new KDBTree.Visitor() {
+            @Override
+            public boolean visit(KDBTree tree) {
+                if (tree.isLeaf()) {
+                    leafs.add(tree.getExtent());
+                }
+                return true;
+            }
+        });
+
+        return leafs;
+    }
+}

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/SpatialRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/SpatialRDD.java
@@ -26,6 +26,8 @@ import org.datasyslab.geospark.enums.IndexType;
 import org.datasyslab.geospark.spatialPartitioning.EqualPartitioning;
 import org.datasyslab.geospark.spatialPartitioning.FlatGridPartitioner;
 import org.datasyslab.geospark.spatialPartitioning.HilbertPartitioning;
+import org.datasyslab.geospark.spatialPartitioning.KDBTree;
+import org.datasyslab.geospark.spatialPartitioning.KDBTreePartitioner;
 import org.datasyslab.geospark.spatialPartitioning.QuadtreePartitioning;
 import org.datasyslab.geospark.spatialPartitioning.RtreePartitioning;
 import org.datasyslab.geospark.spatialPartitioning.SpatialPartitioner;
@@ -226,6 +228,15 @@ public class SpatialRDD<T extends Geometry> implements Serializable{
 				QuadtreePartitioning quadtreePartitioning = new QuadtreePartitioning(samples, paddedBoundary, numPartitions);
 				partitionTree = quadtreePartitioning.getPartitionTree();
 				partitioner = new QuadTreePartitioner(partitionTree);
+				break;
+			}
+			case KDBTREE: {
+				final KDBTree tree = new KDBTree(samples.size() / numPartitions, numPartitions, paddedBoundary);
+				for (final Envelope sample : samples) {
+					tree.insert(sample);
+				}
+				tree.assignLeafIds();
+				partitioner = new KDBTreePartitioner(tree);
 				break;
 			}
 			default:

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/JoinQueryCorrectnessChecker.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/JoinQueryCorrectnessChecker.java
@@ -84,6 +84,7 @@ public class JoinQueryCorrectnessChecker extends GeoSparkTestBase {
         return Arrays.asList(new Object[][] {
             { GridType.RTREE},
             { GridType.QUADTREE},
+            { GridType.KDBTREE},
         });
     }
 
@@ -197,13 +198,8 @@ public class JoinQueryCorrectnessChecker extends GeoSparkTestBase {
         objectRDD.rawSpatialRDD.repartition(4);
         objectRDD.spatialPartitioning(gridType);
         objectRDD.buildIndex(IndexType.RTREE,true);
-        if (gridType == GridType.QUADTREE) {
-            windowRDD.spatialPartitioning(objectRDD.partitionTree);
-        } else {
-            windowRDD.spatialPartitioning(objectRDD.grids);
-        }
+        windowRDD.spatialPartitioning(objectRDD.getPartitioner());
     }
-
 
     /**
      * Test inside point join correctness.

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/JoinTestBase.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/JoinTestBase.java
@@ -132,6 +132,9 @@ class JoinTestBase extends GeoSparkTestBase {
         }
     }
 
+    protected boolean expectToPreserveOriginalDuplicates() {
+        return gridType == GridType.QUADTREE || gridType == GridType.KDBTREE;
+    }
 
     protected <T extends Geometry> long countJoinResults(List<Tuple2<Polygon, HashSet<T>>> results) {
         int count = 0;

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/LineStringJoinTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/LineStringJoinTest.java
@@ -43,6 +43,7 @@ public class LineStringJoinTest extends JoinTestBase {
             { GridType.RTREE, false, 11 },
             { GridType.QUADTREE, true, 11 },
             { GridType.QUADTREE, false, 11},
+            { GridType.KDBTREE, false, 11},
         });
     }
 
@@ -139,7 +140,7 @@ public class LineStringJoinTest extends JoinTestBase {
 
         sanityCheckFlatJoinResults(results);
 
-        long expectedCount = (gridType == GridType.QUADTREE)
+        long expectedCount = expectToPreserveOriginalDuplicates()
             ? expectedMatchWithOriginalDuplicatesCount : expectedMatchCount;
         assertEquals(expectedCount, results.size());
     }

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/PointJoinTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/PointJoinTest.java
@@ -47,6 +47,7 @@ public class PointJoinTest extends JoinTestBase {
             { GridType.RTREE, false, 11 },
             { GridType.QUADTREE, true, 11 },
             { GridType.QUADTREE, false, 11},
+            { GridType.KDBTREE, false, 11},
         });
     }
 
@@ -162,9 +163,9 @@ public class PointJoinTest extends JoinTestBase {
     }
 
     @Test
-    public void testDynamicRTreeWithRectanges() throws Exception {
+    public void testDynamicRTreeWithRectangles() throws Exception {
         final RectangleRDD rectangleRDD = createRectangleRDD();
-        final long expectedCount = (gridType == GridType.QUADTREE)
+        final long expectedCount = expectToPreserveOriginalDuplicates()
             ? expectedRectangleMatchWithOriginalDuplicatesCount : expectedRectangleMatchCount;
         testDynamicRTreeInt(rectangleRDD, IndexType.RTREE, expectedCount);
     }
@@ -172,7 +173,7 @@ public class PointJoinTest extends JoinTestBase {
     @Test
     public void testDynamicRTreeWithPolygons() throws Exception {
         PolygonRDD polygonRDD = createPolygonRDD();
-        final long expectedCount = (gridType == GridType.QUADTREE)
+        final long expectedCount = expectToPreserveOriginalDuplicates()
             ? expectedPolygonMatchWithOriginalDuplicatesCount : expectedPolygonMatchCount;
         testDynamicRTreeInt(polygonRDD, IndexType.RTREE, expectedCount);
     }

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/PolygonJoinTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/PolygonJoinTest.java
@@ -43,6 +43,7 @@ public class PolygonJoinTest extends JoinTestBase {
             { GridType.RTREE, false, 11 },
             { GridType.QUADTREE, true, 11 },
             { GridType.QUADTREE, false, 11},
+            { GridType.KDBTREE, false, 11},
         });
     }
 
@@ -98,7 +99,7 @@ public class PolygonJoinTest extends JoinTestBase {
         final List<Tuple2<Polygon, Polygon>> results = JoinQuery.spatialJoin(spatialRDD, queryRDD, joinParams).collect();
         sanityCheckFlatJoinResults(results);
 
-        final long expectedCount = (gridType == GridType.QUADTREE)
+        final long expectedCount = expectToPreserveOriginalDuplicates()
             ? getExpectedWithOriginalDuplicatesCount(intersects) : getExpectedCount(intersects);
         assertEquals(expectedCount, results.size());
     }

--- a/core/src/test/java/org/datasyslab/geospark/spatialOperator/RectangleJoinTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialOperator/RectangleJoinTest.java
@@ -41,6 +41,7 @@ public class RectangleJoinTest extends JoinTestBase {
             { GridType.RTREE, false, 11 },
             { GridType.QUADTREE, true, 11 },
             { GridType.QUADTREE, false, 11},
+            { GridType.KDBTREE, false, 11},
         });
     }
 
@@ -135,7 +136,7 @@ public class RectangleJoinTest extends JoinTestBase {
 
         sanityCheckFlatJoinResults(result);
 
-        final long expectedCount = (gridType == GridType.QUADTREE)
+        final long expectedCount = expectToPreserveOriginalDuplicates()
             ? expectedMatchWithOriginalDuplicatesCount : expectedMatchCount;
         assertEquals(expectedCount, result.size());
     }


### PR DESCRIPTION
Spatial partitioning based on KDB-tree yields much more even partitions when partitioning based on Quad-tree. At the same time, just like Quad-tree, KDB-tree generates non-overlapping partitions and supports efficient inline de-duplication.