### PR TITLE
Add GeoSpark core hooks for DataFrame

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/enums/FileDataSplitter.java
+++ b/core/src/main/java/org/datasyslab/geospark/enums/FileDataSplitter.java
@@ -14,19 +14,43 @@ import java.io.Serializable;
  * The Enum FileDataSplitter.
  */
 public enum FileDataSplitter implements Serializable{
-	
+
 	/** The csv. */
 	CSV(","),
-	
+
 	/** The tsv. */
 	TSV("\t"),
-	
+
 	/** The geojson. */
 	GEOJSON(""),
-	
+
 	/** The wkt. */
-	WKT("\t");
-	
+	WKT("\t"),
+
+	COMMA(","),
+
+	TAB("\t"),
+
+	QUESTIONMARK("?"),
+
+	SINGLEQUOTE("\'"),
+
+	QUOTE("\""),
+
+	UNDERSCORE("_"),
+
+	DASH("-"),
+
+	PERCENT("%"),
+
+	TILDE("~"),
+
+	PIPE("|"),
+
+	SEMICOLON(";");
+
+
+
 	/**
 	 * Gets the file data splitter.
 	 *
@@ -35,10 +59,10 @@ public enum FileDataSplitter implements Serializable{
 	 */
 	public static FileDataSplitter getFileDataSplitter(String str) {
 	    for (FileDataSplitter me : FileDataSplitter.values()) {
-	        if (me.name().equalsIgnoreCase(str))
+	        if (me.getDelimiter().equalsIgnoreCase(str) || me.name().equalsIgnoreCase(str))
 	            return me;
 	    }
-	    return null;
+	    throw new IllegalArgumentException("["+FileDataSplitter.class+"] Unsupported FileDataSplitter:"+str);
 	}
 	
 	/** The splitter. */

--- a/core/src/main/java/org/datasyslab/geospark/enums/GeometryType.java
+++ b/core/src/main/java/org/datasyslab/geospark/enums/GeometryType.java
@@ -1,0 +1,40 @@
+/**
+ * FILE: GeometryType.java
+ * PATH: org.datasyslab.geospark.enums.GeometryType.java
+ * Copyright (c) 2015-2017 GeoSpark Development Team
+ * All rights reserved.
+ */
+package org.datasyslab.geospark.enums;
+
+import java.io.Serializable;
+
+// TODO: Auto-generated Javadoc
+
+/**
+ * The Enum GeometryType.
+ */
+public enum GeometryType implements Serializable {
+
+    POINT,
+    POLYGON,
+    LINESTRING,
+    MULTIPOINT,
+    MULTIPOLYGON,
+    MULTILINESTRING,
+    GEOMETRYCOLLECTION,
+    CIRCLE;
+
+    /**
+     * Gets the GeometryType.
+     *
+     * @param str the str
+     * @return the GeometryType
+     */
+    public static GeometryType getGeometryType(String str) {
+        for (GeometryType me : GeometryType.values()) {
+            if (me.name().equalsIgnoreCase(str))
+                return me;
+        }
+        throw new IllegalArgumentException("[" + GeometryType.class + "] Unsupported geometry type:" + str);
+    }
+}

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/LineStringFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/LineStringFormatMapper.java
@@ -50,16 +50,6 @@ public class LineStringFormatMapper extends FormatMapper
         while (stringIterator.hasNext()) {
             String line = stringIterator.next();
             switch (splitter) {
-                case CSV:
-                case TSV: {
-                    Coordinate[] coordinates = readCoordinates(line);
-                    LineString lineString = factory.createLineString(coordinates);
-                    if (this.carryInputData) {
-                        lineString.setUserData(line);
-                    }
-                    result.add(lineString);
-                    break;
-                }
                 case GEOJSON: {
                     Geometry geometry = readGeoJSON(line);
                     addGeometry(geometry, result);
@@ -68,6 +58,16 @@ public class LineStringFormatMapper extends FormatMapper
                 case WKT: {
                     Geometry geometry = readWkt(line);
                     addGeometry(geometry, result);
+                    break;
+                }
+                default:
+                {
+                    Coordinate[] coordinates = readCoordinates(line);
+                    LineString lineString = factory.createLineString(coordinates);
+                    if (this.carryInputData) {
+                        lineString.setUserData(line);
+                    }
+                    result.add(lineString);
                     break;
                 }
             }

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/PointFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/PointFormatMapper.java
@@ -50,19 +50,6 @@ public class PointFormatMapper extends FormatMapper
         while (stringIterator.hasNext()) {
             String line = stringIterator.next();
             switch (splitter) {
-                case CSV:
-                case TSV: {
-                    String[] columns = line.split(splitter.getDelimiter());
-                    Coordinate coordinate = new Coordinate(
-                        Double.parseDouble(columns[this.startOffset]),
-                        Double.parseDouble(columns[1 + this.startOffset]));
-                    Point point = factory.createPoint(coordinate);
-                    if (this.carryInputData) {
-                        point.setUserData(line);
-                    }
-                    result.add(point);
-                    break;
-                }
                 case GEOJSON: {
                     Geometry geometry = readGeoJSON(line);
                     addGeometry(geometry, result);
@@ -71,6 +58,17 @@ public class PointFormatMapper extends FormatMapper
                 case WKT:
                     Geometry geometry = readWkt(line);
                     addGeometry(geometry, result);
+                    break;
+                default:
+                    String[] columns = line.split(splitter.getDelimiter());
+                    Coordinate coordinate = new Coordinate(
+                            Double.parseDouble(columns[this.startOffset]),
+                            Double.parseDouble(columns[1 + this.startOffset]));
+                    Point point = factory.createPoint(coordinate);
+                    if (this.carryInputData) {
+                        point.setUserData(line);
+                    }
+                    result.add(point);
                     break;
             }
         }

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/PolygonFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/PolygonFormatMapper.java
@@ -51,17 +51,6 @@ public class PolygonFormatMapper extends FormatMapper
         while (stringIterator.hasNext()) {
             String line = stringIterator.next();
             switch (splitter) {
-                case CSV:
-                case TSV: {
-                    Coordinate[] coordinates = readCoordinates(line);
-                    LinearRing linearRing = factory.createLinearRing(coordinates);
-                    Polygon polygon = factory.createPolygon(linearRing);
-                    if (this.carryInputData) {
-                        polygon.setUserData(line);
-                    }
-                    result.add(polygon);
-                    break;
-                }
                 case GEOJSON: {
                     Geometry geometry = readGeoJSON(line);
                     addGeometry(geometry, result);
@@ -70,6 +59,17 @@ public class PolygonFormatMapper extends FormatMapper
                 case WKT: {
                     Geometry geometry = readWkt(line);
                     addGeometry(geometry, result);
+                    break;
+                }
+                default:
+                {
+                    Coordinate[] coordinates = readCoordinates(line);
+                    LinearRing linearRing = factory.createLinearRing(coordinates);
+                    Polygon polygon = factory.createPolygon(linearRing);
+                    if (this.carryInputData) {
+                        polygon.setUserData(line);
+                    }
+                    result.add(polygon);
                     break;
                 }
             }

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/RectangleFormatMapper.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/RectangleFormatMapper.java
@@ -51,8 +51,18 @@ public class RectangleFormatMapper extends FormatMapper
 		while (stringIterator.hasNext()) {
 			String line = stringIterator.next();
 			switch (splitter) {
-				case CSV:
-				case TSV: {
+				case GEOJSON: {
+					Geometry geometry = readGeoJSON(line);
+					addGeometry(geometry, result);
+					break;
+				}
+				case WKT: {
+					Geometry geometry = readWkt(line);
+					addGeometry(geometry, result);
+					break;
+				}
+				default:
+				{
 					String[] columns = line.split(splitter.getDelimiter());
 					double x1 = Double.parseDouble(columns[this.startOffset]);
 					double x2 = Double.parseDouble(columns[this.startOffset + 2]);
@@ -72,16 +82,6 @@ public class RectangleFormatMapper extends FormatMapper
 						polygon.setUserData(line);
 					}
 					result.add(polygon);
-					break;
-				}
-				case GEOJSON: {
-					Geometry geometry = readGeoJSON(line);
-					addGeometry(geometry, result);
-					break;
-				}
-				case WKT: {
-					Geometry geometry = readWkt(line);
-					addGeometry(geometry, result);
 					break;
 				}
 			}

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShapeSerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/shp/ShapeSerde.java
@@ -1,14 +1,7 @@
 package org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp;
 
 import com.esotericsoftware.kryo.io.Input;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.*;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -66,11 +59,18 @@ public class ShapeSerde {
         }
 
         throw new UnsupportedOperationException("Geometry type is not supported: " +
-            geometry.getClass().getSimpleName());
+                geometry.getClass().getSimpleName());
     }
 
     public static Geometry deserialize(Input input, GeometryFactory factory) {
         ShapeReader reader = ShapeReaderFactory.fromInput(input);
+        ShapeType type = ShapeType.getType(reader.readByte());
+        ShapeParser parser = type.getParser(factory);
+        return parser.parseShape(reader);
+    }
+
+    public static Geometry deserialize(byte[] input, GeometryFactory factory) {
+        ShapeReader reader = ShapeReaderFactory.fromByteBuffer(ByteBuffer.wrap(input));
         ShapeType type = ShapeType.getType(reader.readByte());
         ShapeParser parser = type.getParser(factory);
         return parser.parseShape(reader);

--- a/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
+++ b/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
@@ -21,7 +21,7 @@ public class GeoSparkKryoRegistrator implements KryoRegistrator {
     public void registerClasses(Kryo kryo) {
         GeometrySerde serializer = new GeometrySerde();
 
-        log.warn("Registering custom serializers for geometry types");
+        log.info("Registering custom serializers for geometry types");
 
         kryo.register(Point.class, serializer);
         kryo.register(LineString.class, serializer);

--- a/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
+++ b/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
@@ -21,7 +21,7 @@ public class GeoSparkKryoRegistrator implements KryoRegistrator {
     public void registerClasses(Kryo kryo) {
         GeometrySerde serializer = new GeometrySerde();
 
-        log.info("Registering custom serializers for geometry types");
+        log.warn("Registering custom serializers for geometry types");
 
         kryo.register(Point.class, serializer);
         kryo.register(LineString.class, serializer);


### PR DESCRIPTION
This PR includes the following changes:
1. Add more delimiter support to FileDataSplitter
2. Open all functions in format mappers so that GeoSpark sql can connect with GeoSpark core
3. Add one more deserialization function in ShapeSerde in case GeoSpark sql will use it in the future. Currently GeoSparkSql uses GeometrySerde to do UDT serialization and deserialization