### PR TITLE
Relax the left and right order of SpatialRangeQuery input parameters

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/rangeJudgement/JudgementBase.java
+++ b/core/src/main/java/org/datasyslab/geospark/rangeJudgement/JudgementBase.java
@@ -11,6 +11,7 @@ abstract class JudgementBase<U extends Geometry> implements Serializable {
     private static final Logger log = LogManager.getLogger(JudgementBase.class);
     private boolean considerBoundaryIntersection;
     U queryGeometry;
+    protected boolean leftCoveredByRight = true;
 
     /**
      * Instantiates a new range filter using index.
@@ -18,10 +19,11 @@ abstract class JudgementBase<U extends Geometry> implements Serializable {
      * @param queryWindow the query window
      * @param considerBoundaryIntersection the consider boundary intersection
      */
-    public JudgementBase(U queryWindow,boolean considerBoundaryIntersection)
+    public JudgementBase(U queryWindow,boolean considerBoundaryIntersection, boolean leftCoveredByRight)
     {
         this.considerBoundaryIntersection=considerBoundaryIntersection;
         this.queryGeometry=queryWindow;
+        this.leftCoveredByRight = leftCoveredByRight;
     }
     protected boolean match(Geometry spatialObject, Geometry queryWindow) {
         if(considerBoundaryIntersection)

--- a/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilter.java
+++ b/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilter.java
@@ -14,14 +14,22 @@ import org.apache.spark.api.java.function.Function;
 
 public class RangeFilter<U extends Geometry, T extends Geometry> extends JudgementBase implements Function<T, Boolean> {
 
-	public RangeFilter(U queryWindow, boolean considerBoundaryIntersection) {
-		super(queryWindow, considerBoundaryIntersection);
+	public RangeFilter(U queryWindow, boolean considerBoundaryIntersection, boolean leftCoveredByRight) {
+		super(queryWindow, considerBoundaryIntersection, leftCoveredByRight);
 	}
+
 
 	/* (non-Javadoc)
          * @see org.apache.spark.api.java.function.Function#call(java.lang.Object)
          */
 	public Boolean call(T geometry) throws Exception {
-		return match(geometry, queryGeometry);
+		if (leftCoveredByRight)
+		{
+			return match(geometry, queryGeometry);
+		}
+		else
+		{
+			return match(queryGeometry, queryGeometry);
+		}
 	}
 }

--- a/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilterUsingIndex.java
+++ b/core/src/main/java/org/datasyslab/geospark/rangeJudgement/RangeFilterUsingIndex.java
@@ -18,8 +18,8 @@ import java.util.List;
 
 public class RangeFilterUsingIndex<U extends Geometry, T extends Geometry> extends JudgementBase implements FlatMapFunction<Iterator<SpatialIndex>, T>{
 
-	public RangeFilterUsingIndex(U queryWindow, boolean considerBoundaryIntersection) {
-		super(queryWindow, considerBoundaryIntersection);
+	public RangeFilterUsingIndex(U queryWindow, boolean considerBoundaryIntersection, boolean leftCoveredByRight) {
+		super(queryWindow, considerBoundaryIntersection, leftCoveredByRight);
 	}
 	/**
 	 * Call.
@@ -39,10 +39,21 @@ public class RangeFilterUsingIndex<U extends Geometry, T extends Geometry> exten
 		List<T> tempResults = treeIndex.query(this.queryGeometry.getEnvelopeInternal());
 		for (T tempResult:tempResults)
 		{
-			if(match(tempResult,queryGeometry))
+			if (leftCoveredByRight)
 			{
-				results.add(tempResult);
+				if(match(tempResult,queryGeometry))
+				{
+					results.add(tempResult);
+				}
 			}
+			else
+			{
+				if(match(queryGeometry,tempResult))
+				{
+					results.add(tempResult);
+				}
+			}
+
 		}
 		return results.iterator();
 	}

--- a/core/src/main/java/org/datasyslab/geospark/spatialOperator/RangeQuery.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialOperator/RangeQuery.java
@@ -22,7 +22,7 @@ import org.datasyslab.geospark.utils.CRSTransformation;
 public class RangeQuery implements Serializable{
 
 	/**
-	 * Spatial range query.
+	 * Spatial range query. Return objects in SpatialRDD are covered/intersected by originalQueryGeometry
 	 *
 	 * @param spatialRDD the spatial RDD
 	 * @param originalQueryGeometry the original query window
@@ -44,15 +44,15 @@ public class RangeQuery implements Serializable{
 			if(spatialRDD.indexedRawRDD == null) {
 				throw new Exception("[RangeQuery][SpatialRangeQuery] Index doesn't exist. Please build index on rawSpatialRDD.");
 			}
-			return spatialRDD.indexedRawRDD.mapPartitions(new RangeFilterUsingIndex(queryGeometry,considerBoundaryIntersection));
+			return spatialRDD.indexedRawRDD.mapPartitions(new RangeFilterUsingIndex(queryGeometry,considerBoundaryIntersection,true));
 		}
 		else{
-			return spatialRDD.getRawSpatialRDD().filter(new RangeFilter(queryGeometry, considerBoundaryIntersection));
+			return spatialRDD.getRawSpatialRDD().filter(new RangeFilter(queryGeometry, considerBoundaryIntersection,true));
 		}
 	}
 
 	/**
-	 * Spatial range query.
+	 * Spatial range query. Return objects in SpatialRDD are covered/intersected by queryWindow/Envelope
 	 *
 	 * @param spatialRDD the spatial RDD
 	 * @param queryWindow the original query window
@@ -72,5 +72,58 @@ public class RangeQuery implements Serializable{
 		GeometryFactory geometryFactory = new GeometryFactory();
 		U queryGeometry = (U) geometryFactory.createPolygon(coordinates);
 		return SpatialRangeQuery(spatialRDD, queryGeometry, considerBoundaryIntersection, useIndex);
+	}
+
+    /**
+     * Spatial range query. Return objects in SpatialRDD cover/intersect by queryWindow/Envelope
+     *
+     * @param spatialRDD the spatial RDD
+     * @param queryWindow the original query window
+     * @param considerBoundaryIntersection the consider boundary intersection
+     * @param useIndex the use index
+     * @return the java RDD
+     * @throws Exception the exception
+     */
+    public static <U extends Geometry, T extends Geometry> JavaRDD<T> SpatialRangeQuery(Envelope queryWindow, SpatialRDD<T> spatialRDD, boolean considerBoundaryIntersection, boolean useIndex) throws Exception
+    {
+        Coordinate[] coordinates = new Coordinate[5];
+        coordinates[0]=new Coordinate(queryWindow.getMinX(), queryWindow.getMinY());
+        coordinates[1]=new Coordinate(queryWindow.getMinX(), queryWindow.getMaxY());
+        coordinates[2]=new Coordinate(queryWindow.getMaxX(), queryWindow.getMaxY());
+        coordinates[3]=new Coordinate(queryWindow.getMaxX(), queryWindow.getMinY());
+        coordinates[4]=coordinates[0];
+        GeometryFactory geometryFactory = new GeometryFactory();
+        U queryGeometry = (U) geometryFactory.createPolygon(coordinates);
+        return SpatialRangeQuery(queryGeometry, spatialRDD, considerBoundaryIntersection, useIndex);
+    }
+
+    /**
+     * Spatial range query. Return objects in SpatialRDD cover/intersect originalQueryGeometry
+     *
+     * @param spatialRDD the spatial RDD
+     * @param originalQueryGeometry the original query window
+     * @param considerBoundaryIntersection the consider boundary intersection
+     * @param useIndex the use index
+     * @return the java RDD
+     * @throws Exception the exception
+     */
+	public static <U extends Geometry, T extends Geometry> JavaRDD<T> SpatialRangeQuery(U originalQueryGeometry, SpatialRDD<T> spatialRDD, boolean considerBoundaryIntersection, boolean useIndex) throws Exception
+	{
+		U queryGeometry = originalQueryGeometry;
+		if(spatialRDD.getCRStransformation())
+		{
+			queryGeometry = CRSTransformation.Transform(spatialRDD.getSourceEpsgCode(),spatialRDD.getTargetEpgsgCode(), originalQueryGeometry);
+		}
+
+		if(useIndex==true)
+		{
+			if(spatialRDD.indexedRawRDD == null) {
+				throw new Exception("[RangeQuery][SpatialRangeQuery] Index doesn't exist. Please build index on rawSpatialRDD.");
+			}
+			return spatialRDD.indexedRawRDD.mapPartitions(new RangeFilterUsingIndex(queryGeometry,considerBoundaryIntersection,false));
+		}
+		else{
+			return spatialRDD.getRawSpatialRDD().filter(new RangeFilter(queryGeometry, considerBoundaryIntersection,false));
+		}
 	}
 }


### PR DESCRIPTION
This PR includes the following change: Relax the left and right order of inputRDD and queryGeometry in a SpatialRangeQuery.

The old SpatialRangeQuery API is (spatialRDD, queryWindow,...) which returns objects are covered/intersected by queryWindow.

This PR brings out one more SpatialRangeQuery API which is (queryWIndow, spatialRDD) which returns objects cover/intersect the queryWindow.
