### PR TITLE
Urgent patch: Add an adapter function to convert Join result to DataFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ GeoSpark artifacts are hosted in Maven Central: [**Maven Central Coordinates**](
 ##  Version release notes: [click here](https://github.com/DataSystemsLab/GeoSpark/wiki/GeoSpark-Full-Version-Release-notes)
 
 ## News!
+* GeoSpark 0.9.1 is released: This is an urgent patch for 0.9.0 which provides an adapter to convert JoinQuery result to DataFrame. [GeoSpark SQL Maven Central coordinate](https://github.com/DataSystemsLab/GeoSpark/wiki/GeoSparkSQL-Maven-Central-Coordinates)
 * GeoSpark 0.9.0 is released (more details in [Release notes](https://github.com/DataSystemsLab/GeoSpark/wiki/GeoSpark-Full-Version-Release-notes))
 	* much less memory consumption powered by GeoSpark customized serializer
 	* much faster spatial/distance join speed
 	* SpatialRDD that supports heterogenous geometries
 	* range, join, knn queries on heterogenous geometries
 	* Add KDB-Tree spatial partitioning
-	* Create SpatialRDD from DataFrame / Create DataFrame from SpatialRDD (requires GeoSparkSQL) ([Scala example](https://github.com/DataSystemsLab/GeoSpark/blob/master/sql/src/test/scala/org/datasyslab/geosparksql/readTestScala.scala)[Java example](https://github.com/DataSystemsLab/GeoSpark/blob/master/sql/src/test/java/org/datasyslab/geosparksql/readTestJava.java))
+	* Create SpatialRDD from DataFrame / Create DataFrame from SpatialRDD (requires GeoSparkSQL) ([Scala example](https://github.com/DataSystemsLab/GeoSpark/blob/master/sql/src/test/scala/org/datasyslab/geosparksql/readTestScala.scala),[Java example](https://github.com/DataSystemsLab/GeoSpark/blob/master/sql/src/test/java/org/datasyslab/geosparksql/readTestJava.java))
 * Welcome GeoSpark new contributor, Masha Basmanova (@mbasmanova) from Facebook. Masha has contributed more than 10 PRs to GeoSpark on refactoring GeoSpark architecture and improving GeoSpark join performance!
 * Welcome GeoSpark new contributor, Zongsi Zhang (@zongsizhang) from Arizona State University. Zongsi participated the design of GeoSpark Shapefile parser and he has done a great job!
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
 	<artifactId>geospark</artifactId>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Geospatial extension for Apache Spark</description>

--- a/core/src/main/java/org/datasyslab/geospark/spatialOperator/JoinQuery.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialOperator/JoinQuery.java
@@ -262,7 +262,6 @@ public class JoinQuery {
      * 
      * Duplicates present in the input RDDs will be reflected in the join results.
      *
-     * @param <U> Type of the geometries in queryRDD/circleRDD set
      * @param <T> Type of the geometries in spatialRDD set
      * @param spatialRDD Set of geometries
      * @param queryRDD Set of geometries
@@ -296,7 +295,6 @@ public class JoinQuery {
      * Because the results are reported as a HashSet, any duplicates in the original spatialRDD will
      * be eliminated.
      *
-     * @param <U> Type of the geometries in queryRDD/circleRDD set
      * @param <T> Type of the geometries in spatialRDD set
      * @param spatialRDD Set of geometries
      * @param queryRDD Set of geometries
@@ -319,7 +317,6 @@ public class JoinQuery {
     /**
      * A faster version of {@link #DistanceJoinQuery(SpatialRDD, CircleRDD, boolean, boolean)} which may produce duplicate results.
      *
-     * @param <U> Type of the geometries in queryRDD/circleRDD set
      * @param <T> Type of the geometries in spatialRDD set
      * @param spatialRDD Set of geometries
      * @param queryRDD Set of geometries
@@ -344,7 +341,6 @@ public class JoinQuery {
      * 
      * Duplicates present in the input RDDs will be reflected in the join results.
      *
-     * @param <U> Type of the geometries in queryRDD/circleRDD set
      * @param <T> Type of the geometries in spatialRDD set
      * @param spatialRDD Set of geometries
      * @param queryRDD Set of geometries

--- a/core/src/main/java/org/datasyslab/geospark/spatialOperator/JoinQuery.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialOperator/JoinQuery.java
@@ -271,12 +271,12 @@ public class JoinQuery {
      * @return RDD of pairs of matching geometries
      * @throws Exception the exception
      */
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, T> DistanceJoinQueryFlat(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, T> DistanceJoinQueryFlat(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
         final JoinParams joinParams = new JoinParams(useIndex, considerBoundaryIntersection, false);
         return distanceJoin(spatialRDD, queryRDD, joinParams);
     }
 
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, T> DistanceJoinQueryFlat(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, T> DistanceJoinQueryFlat(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
         return distanceJoin(spatialRDD, queryRDD, joinParams);
     }
 
@@ -305,14 +305,14 @@ public class JoinQuery {
      * @return RDD of pairs where each pair contains a geometry and a set of matching geometries
      * @throws Exception the exception
      */
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, HashSet<T>> DistanceJoinQuery(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, HashSet<T>> DistanceJoinQuery(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
         final JoinParams joinParams = new JoinParams(useIndex, considerBoundaryIntersection, false);
-        JavaPairRDD<U,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+        JavaPairRDD<Geometry,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return collectGeometriesByKey(joinResults);
     }
 
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, HashSet<T>> DistanceJoinQuery(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
-        JavaPairRDD<U,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+    public static <T extends Geometry> JavaPairRDD<Geometry, HashSet<T>> DistanceJoinQuery(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
+        JavaPairRDD<Geometry,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return collectGeometriesByKey(joinResults);
     }
 
@@ -328,14 +328,14 @@ public class JoinQuery {
      * @return RDD of pairs where each pair contains a geometry and a set of matching geometries
      * @throws Exception the exception
      */
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, HashSet<T>> DistanceJoinQueryWithDuplicates(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, HashSet<T>> DistanceJoinQueryWithDuplicates(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
         final JoinParams joinParams = new JoinParams(useIndex, considerBoundaryIntersection, true);
-        JavaPairRDD<U,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+        JavaPairRDD<Geometry,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return collectGeometriesByKey(joinResults);
     }
 
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, HashSet<T>> DistanceJoinQueryWithDuplicates(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
-        JavaPairRDD<U,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+    public static <T extends Geometry> JavaPairRDD<Geometry, HashSet<T>> DistanceJoinQueryWithDuplicates(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
+        JavaPairRDD<Geometry,T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return collectGeometriesByKey(joinResults);
     }
 
@@ -353,14 +353,14 @@ public class JoinQuery {
      * @return the result of {@link #DistanceJoinQueryFlat(SpatialRDD, CircleRDD, boolean, boolean)}, but in this pair RDD, each pair contains a geometry and the count of matching geometries
      * @throws Exception the exception
      */
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, Long> DistanceJoinQueryCountByKey(SpatialRDD<T> spatialRDD,CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, Long> DistanceJoinQueryCountByKey(SpatialRDD<T> spatialRDD,CircleRDD queryRDD, boolean useIndex,boolean considerBoundaryIntersection) throws Exception {
         final JoinParams joinParams = new JoinParams(useIndex, considerBoundaryIntersection, false);
-        final JavaPairRDD<U, T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+        final JavaPairRDD<Geometry, T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return countGeometriesByKey(joinResults);
     }
 
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, Long> DistanceJoinQueryCountByKey(SpatialRDD<T> spatialRDD,CircleRDD queryRDD, JoinParams joinParams) throws Exception {
-        final JavaPairRDD<U, T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
+    public static <T extends Geometry> JavaPairRDD<Geometry, Long> DistanceJoinQueryCountByKey(SpatialRDD<T> spatialRDD,CircleRDD queryRDD, JoinParams joinParams) throws Exception {
+        final JavaPairRDD<Geometry, T> joinResults = distanceJoin(spatialRDD, queryRDD, joinParams);
         return countGeometriesByKey(joinResults);
     }
 
@@ -369,12 +369,12 @@ public class JoinQuery {
      *     Note: INTERNAL FUNCTION. API COMPATIBILITY IS NOT GUARANTEED. DO NOT USE IF YOU DON'T KNOW WHAT IT IS.
      * </p>
      */
-    public static <U extends Geometry, T extends Geometry> JavaPairRDD<U, T> distanceJoin(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
+    public static <T extends Geometry> JavaPairRDD<Geometry, T> distanceJoin(SpatialRDD<T> spatialRDD, CircleRDD queryRDD, JoinParams joinParams) throws Exception {
         JavaPairRDD<Circle,T> joinResults = spatialJoin(queryRDD, spatialRDD, joinParams);
-        return joinResults.mapToPair(new PairFunction<Tuple2<Circle, T>, U, T>() {
+        return joinResults.mapToPair(new PairFunction<Tuple2<Circle, T>, Geometry, T>() {
             @Override
-            public Tuple2<U, T> call(Tuple2<Circle, T> circleTTuple2) throws Exception {
-                return new Tuple2<U,T>((U) circleTTuple2._1().getCenterGeometry(),circleTTuple2._2());
+            public Tuple2<Geometry, T> call(Tuple2<Circle, T> circleTTuple2) throws Exception {
+                return new Tuple2<Geometry,T>((Geometry) circleTTuple2._1().getCenterGeometry(),circleTTuple2._2());
             }
         });
     }

--- a/core/src/test/scala/org/datasyslab/geospark/scalaTest.scala
+++ b/core/src/test/scala/org/datasyslab/geospark/scalaTest.scala
@@ -53,7 +53,7 @@ class scalaTest extends FunSpec with BeforeAndAfterAll {
 		val geometryFactory=new GeometryFactory()
 		val kNNQueryPoint=geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
 		val rangeQueryWindow=new Envelope (-90.01,-80.01,30.01,40.01)
-		val joinQueryPartitioningType = GridType.RTREE
+		val joinQueryPartitioningType = GridType.QUADTREE
 		val eachQueryLoopTimes=1
 
 		it("should pass spatial range query") {
@@ -164,7 +164,7 @@ class scalaTest extends FunSpec with BeforeAndAfterAll {
 			val objectRDD = new PointRDD(sc, PointRDDInputLocation, PointRDDOffset, PointRDDSplitter, true, StorageLevel.MEMORY_ONLY)
 			val queryWindowRDD = new CircleRDD(objectRDD,0.1)
 
-			objectRDD.spatialPartitioning(GridType.RTREE)
+			objectRDD.spatialPartitioning(GridType.QUADTREE)
 			queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
 
 			for(i <- 1 to eachQueryLoopTimes)
@@ -177,7 +177,7 @@ class scalaTest extends FunSpec with BeforeAndAfterAll {
 			val objectRDD = new PointRDD(sc, PointRDDInputLocation, PointRDDOffset, PointRDDSplitter, true, StorageLevel.MEMORY_ONLY)
 			val queryWindowRDD = new CircleRDD(objectRDD,0.1)
 
-			objectRDD.spatialPartitioning(GridType.RTREE)
+			objectRDD.spatialPartitioning(GridType.QUADTREE)
 			queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
 
 			objectRDD.buildIndex(IndexType.RTREE,true)

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
 	<artifactId>geospark-sql</artifactId>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>SQL Extension of GeoSpark</description>
@@ -51,7 +51,7 @@
             <artifactId>geospark</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/GeometryWrapper.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/GeometryWrapper.scala
@@ -14,7 +14,7 @@ class GeometryWrapper extends Serializable {
   def this(geometryString: String, fileDataSplitter: FileDataSplitter, geometryType: GeometryType)
   {
     this()
-    var formatMapper = new FormatMapper(fileDataSplitter, true, geometryType)
+    var formatMapper = new FormatMapper(fileDataSplitter, false, geometryType)
     this.geometry = formatMapper.readGeometry(geometryString)
   }
 


### PR DESCRIPTION
This PR is an urgent patch to GeoSpark 0.9.0 and upgrades GeoSpark to 0.9.1. It includes the following content:

* [GeoSpark-core]: solve the return object type problem of DistanceJoinQuery so that GeoSpark SQL can access it. 
* [GeoSpark-SQL]: add an adapter which converts join query result to a DataFrame