### PR TITLE
add kryo serializer for SpatialIndex type

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.datasyslab</groupId>
             <artifactId>JTSplus</artifactId>
-            <version>0.1.3</version>
+            <version>0.1.4</version>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/GeometrySerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/GeometrySerde.java
@@ -13,7 +13,7 @@ import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp.Shape
  * Provides methods to efficiently serialize and deserialize geometry types.
  *
  * Supports Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon,
- * GeometryCollection and Circle types.
+ * GeometryCollection, Circle and Envelope types.
  *
  * First byte contains {@link Type#id}. Then go type-specific bytes, followed
  * by user-data attached to the geometry.

--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/GeometrySerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/GeometrySerde.java
@@ -5,15 +5,7 @@ import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.*;
 import org.apache.log4j.Logger;
 import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp.ShapeSerde;
 
@@ -35,7 +27,8 @@ public class GeometrySerde extends Serializer {
     {
         SHAPE(0),
         CIRCLE(1),
-        GEOMETRYCOLLECTION(2);
+        GEOMETRYCOLLECTION(2),
+        ENVELOPE(3);
 
         private final int id;
 
@@ -76,6 +69,13 @@ public class GeometrySerde extends Serializer {
                 writeGeometry(kryo, out, collection.getGeometryN(i));
             }
             writeUserData(kryo, out, collection);
+        } else if( object instanceof Envelope) {
+            Envelope envelope = (Envelope) object;
+            writeType(out, Type.ENVELOPE);
+            out.writeDouble(envelope.getMinX());
+            out.writeDouble(envelope.getMaxX());
+            out.writeDouble(envelope.getMinY());
+            out.writeDouble(envelope.getMaxY());
         } else {
             throw new UnsupportedOperationException("Cannot serialize object of type " +
                 object.getClass().getName());
@@ -125,6 +125,13 @@ public class GeometrySerde extends Serializer {
                 GeometryCollection collection = geometryFactory.createGeometryCollection(geometries);
                 collection.setUserData(readUserData(kryo, input));
                 return collection;
+            }
+            case ENVELOPE: {
+                double xMin = input.readDouble();
+                double xMax = input.readDouble();
+                double yMin = input.readDouble();
+                double yMax = input.readDouble();
+                return new Envelope(xMin,xMax, yMin, yMax );
             }
             default:
                 throw new UnsupportedOperationException(

--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
@@ -19,6 +19,14 @@ import org.apache.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
+
+/**
+ * Provides methods to efficiently serialize and deserialize spatialIndex types.
+ *
+ * Support Quadtree, STRtree types
+ *
+ * trees are serialized recursively.
+ */
 public class SpatialIndexSerde extends Serializer{
 
     private static final Logger log = Logger.getLogger(SpatialIndexSerde.class);

--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
@@ -11,6 +11,8 @@ import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.quadtree.Node;
 import com.vividsolutions.jts.index.quadtree.NodeBase;
 import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.index.strtree.AbstractNode;
+import com.vividsolutions.jts.index.strtree.ItemBoundable;
 import com.vividsolutions.jts.index.strtree.STRtree;
 import org.apache.log4j.Logger;
 
@@ -61,35 +63,98 @@ public class SpatialIndexSerde extends Serializer{
         if( o instanceof Quadtree){
             // serialize quadtree index
             writeType(output, Type.QUADTREE);
-            writeQuadTree(kryo,output, ((Quadtree) o));
+            Quadtree tree = (Quadtree)o;
+            if(tree.isEmpty()){
+                output.writeByte(0);
+            }else {
+                output.writeByte(1);
+                // write root
+                List items = tree.getRoot().getItems();
+                output.writeInt(items.size());
+                for(Object item : items){
+                    geometrySerde.write(kryo, output, item);
+                }
+                Node[] subNodes= tree.getRoot().getSubnode();
+                for(int i = 0;i < 4; ++i){
+                    writeQuadTreeNode(kryo, output, subNodes[i]);
+                }
+            }
         }else if(o instanceof STRtree){
             //serialize rtree index
             writeType(output, Type.RTREE);
+            STRtree tree = (STRtree)o;
+            output.writeInt(tree.getNodeCapacity());
+            if(tree.isEmpty()){
+                output.writeByte(0);
+            }else{
+                output.writeByte(1);
+                // write head
+                output.writeByte(tree.isBuilt() ? 1 : 0);
+                if(!tree.isBuilt()){
+                    // if not built, itemBoundables will not be null, record it
+                    ArrayList itemBoundables = tree.getItemBoundables();
+                    output.writeInt(itemBoundables.size());
+                    for(Object obj : itemBoundables){
+                        if(!(obj instanceof ItemBoundable)) throw new UnsupportedOperationException(" itemBoundables should only contain ItemBoundable objects ");
+                        ItemBoundable itemBoundable = (ItemBoundable) obj;
+                        // write envelope
+                        writeItemBoundable(kryo, output, itemBoundable);
+                    }
+                }else{
+                    // if built, write from root
+                    writeSTRTreeNode(kryo, output, tree.getRoot());
+                }
+            }
+        } else {
+            throw new UnsupportedOperationException(" index type not supported ");
         }
     }
 
-    /**
-     * write head and root node
-     * byte  1byte  empty or not, 0 means empty, 1 means not empty
-     *
-     * @param kryo
-     * @param output
-     * @param tree
-     */
-    private void writeQuadTree(Kryo kryo, Output output, Quadtree tree){
-        if(tree.isEmpty()){
-            output.writeByte(0);
-        }else {
-            output.writeByte(1);
-            // write root
-            List items = tree.getRoot().getItems();
-            output.writeInt(items.size());
-            for(Object item : items){
-                geometrySerde.write(kryo, output, item);
+    @Override
+    public Object read(Kryo kryo, Input input, Class aClass) {
+        byte typeID = input.readByte();
+        Type indexType = Type.fromId(typeID);
+        switch (indexType){
+            case QUADTREE:{
+                Quadtree index = new Quadtree();
+                boolean notEmpty = (input.readByte() & 0x01) == 1;
+                if(!notEmpty) return index;
+                int itemSize = input.readInt();
+                List items = new ArrayList();
+                for(int i = 0;i < itemSize; ++i){
+                    items.add(geometrySerde.read(kryo, input, Geometry.class));
+                }
+                index.getRoot().setItems(items);
+                for(int i = 0;i < 4; ++i){
+                    index.getRoot().getSubnode()[i] = readQuadTreeNode(kryo, input);
+                }
+                return index;
             }
-            Node[] subNodes= tree.getRoot().getSubnode();
-            for(int i = 0;i < 4; ++i){
-                writeQuadTreeNode(kryo, output, subNodes[i]);
+            case RTREE:{
+                int nodeCapacity = input.readInt();
+                boolean notEmpty = (input.readByte() & 0x01) == 1;
+                if(notEmpty){
+                    STRtree index = new STRtree(nodeCapacity);
+                    boolean built = (input.readByte() & 0x01) == 1;
+                    if(built){
+                        // if built, root is not null, set itemBoundables to null
+                        index.setBuilt(true);
+                        index.setItemBoundables(null);
+                        index.setRoot(readSTRtreeNode(kryo, input));
+                    }else{
+                        // if not built, just read itemBoundables
+                        ArrayList itemBoundables = new ArrayList();
+                        int itemSize = input.readInt();
+                        for(int i = 0;i < itemSize; ++i){
+                            itemBoundables.add(readItemBoundable(kryo, input));
+                        }
+                        index.setItemBoundables(itemBoundables);
+                    }
+                    return index;
+                }else return new STRtree(nodeCapacity);
+            }
+            default:{
+                throw new UnsupportedOperationException("can't deserialize spatial index of type" + indexType);
             }
         }
     }
@@ -115,40 +180,6 @@ public class SpatialIndexSerde extends Serializer{
         }
     }
 
-    private void writeType(Output output, Type type){
-        output.writeByte((byte)type.id);
-    }
-
-    @Override
-    public Object read(Kryo kryo, Input input, Class aClass) {
-        byte typeID = input.readByte();
-        Type indexType = Type.fromId(typeID);
-        switch (indexType){
-            case QUADTREE:{
-                Quadtree index = new Quadtree();
-                boolean notEmpty = (input.readByte() & 0x01) == 1;
-                if(!notEmpty) return index;
-                int itemSize = input.readInt();
-                List items = new ArrayList();
-                for(int i = 0;i < itemSize; ++i){
-                    items.add(geometrySerde.read(kryo, input, Geometry.class));
-                }
-                index.getRoot().setItems(items);
-                for(int i = 0;i < 4; ++i){
-                    index.getRoot().getSubnode()[i] = readQuadTreeNode(kryo, input);
-                }
-                return index;
-            }
-            case RTREE:{
-                break;
-            }
-            default:{
-                throw new UnsupportedOperationException("can't deserialize spatial index of type" + indexType);
-            }
-        }
-        return null;
-    }
-
     private Node readQuadTreeNode(Kryo kryo, Input input){
         boolean notEmpty = (input.readByte() & 0x01) == 1;
         if(!notEmpty) return null;
@@ -166,5 +197,69 @@ public class SpatialIndexSerde extends Serializer{
             node.getSubnode()[i] = readQuadTreeNode(kryo, input);
         }
         return node;
+    }
+
+    private void writeSTRTreeNode(Kryo kryo, Output output, AbstractNode node){
+        // write head
+        output.writeInt(node.getLevel());
+        // write children
+        List children = node.getChildBoundables();
+        int childrenSize = children.size();
+        output.writeInt(childrenSize);
+        // if children not empty, write children
+        if(childrenSize > 0){
+            if(children.get(0) instanceof AbstractNode){
+                // write type as 0, non-leaf node
+                output.writeByte(0);
+                for(Object obj : children){
+                    AbstractNode child = (AbstractNode) obj;
+                    writeSTRTreeNode(kryo, output, child);
+                }
+            }else if(children.get(0) instanceof ItemBoundable){
+                // write type as 1, leaf node
+                output.writeByte(1);
+                // for leaf node, write items
+                for(Object obj : children){
+                    writeItemBoundable(kryo, output, (ItemBoundable)obj);
+                }
+            }else{
+                throw new UnsupportedOperationException("wrong node type of STRtree");
+            }
+        }
+    }
+
+    private STRtree.STRtreeNode readSTRtreeNode(Kryo kryo, Input input){
+        int level = input.readInt();
+        STRtree.STRtreeNode node = new STRtree.STRtreeNode(level);
+        int childrenSize = input.readInt();
+        boolean isLeaf = (input.readByte() & 0x01) == 1;
+        ArrayList children = new ArrayList();
+        if(isLeaf){
+            for(int i = 0;i < childrenSize; ++i){
+                children.add(readItemBoundable(kryo, input));
+            }
+        }else{
+            for(int i = 0;i < childrenSize; ++i){
+                children.add(readSTRtreeNode(kryo, input));
+            }
+        }
+        node.setChildBoundables(children);
+        return node;
+    }
+
+    private void writeItemBoundable(Kryo kryo, Output output, ItemBoundable itemBoundable){
+        geometrySerde.write(kryo, output, itemBoundable.getBounds());
+        geometrySerde.write(kryo, output, itemBoundable.getItem());
+    }
+
+    private ItemBoundable readItemBoundable(Kryo kryo, Input input) {
+        return new ItemBoundable(
+                geometrySerde.read(kryo, input, Envelope.class),
+                geometrySerde.read(kryo, input, Geometry.class)
+        );
+    }
+
+    private void writeType(Output output, Type type){
+        output.writeByte((byte)type.id);
     }
 }

--- a/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
+++ b/core/src/main/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerde.java
@@ -1,0 +1,170 @@
+package org.datasyslab.geospark.geometryObjects;
+
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.index.SpatialIndex;
+import com.vividsolutions.jts.index.quadtree.Node;
+import com.vividsolutions.jts.index.quadtree.NodeBase;
+import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.index.strtree.STRtree;
+import org.apache.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpatialIndexSerde extends Serializer{
+
+    private static final Logger log = Logger.getLogger(SpatialIndexSerde.class);
+
+    private GeometrySerde geometrySerde;
+
+    public SpatialIndexSerde() {
+        super();
+        geometrySerde = new GeometrySerde();
+    }
+
+    public SpatialIndexSerde(GeometrySerde geometrySerde) {
+        super();
+        this.geometrySerde = geometrySerde;
+    }
+
+    private enum Type{
+
+        QUADTREE(0),
+        RTREE(1);
+
+        private final int id;
+
+        Type(int id) {
+            this.id = id;
+        }
+
+        public static Type fromId(int id)
+        {
+            for (Type type : values()) {
+                if (type.id == id) {
+                    return type;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Object o) {
+        if( o instanceof Quadtree){
+            // serialize quadtree index
+            writeType(output, Type.QUADTREE);
+            writeQuadTree(kryo,output, ((Quadtree) o));
+        }else if(o instanceof STRtree){
+            //serialize rtree index
+            writeType(output, Type.RTREE);
+        }
+    }
+
+    /**
+     * write head and root node
+     * byte  1byte  empty or not, 0 means empty, 1 means not empty
+     *
+     * @param kryo
+     * @param output
+     * @param tree
+     */
+    private void writeQuadTree(Kryo kryo, Output output, Quadtree tree){
+        if(tree.isEmpty()){
+            output.writeByte(0);
+        }else {
+            output.writeByte(1);
+            // write root
+            List items = tree.getRoot().getItems();
+            output.writeInt(items.size());
+            for(Object item : items){
+                geometrySerde.write(kryo, output, item);
+            }
+            Node[] subNodes= tree.getRoot().getSubnode();
+            for(int i = 0;i < 4; ++i){
+                writeQuadTreeNode(kryo, output, subNodes[i]);
+            }
+        }
+    }
+
+    private void writeQuadTreeNode(Kryo kryo, Output output, Node node){
+        // write head first
+        if(node == null || node.isEmpty()){
+            output.writeByte(0);
+        }else{ // not empty
+            output.writeByte(1);
+            // write node information, envelope and level
+            geometrySerde.write(kryo, output, node.getEnvelope());
+            output.writeInt(node.getLevel());
+            List items = node.getItems();
+            output.writeInt(items.size());
+            for( Object obj : items){
+                geometrySerde.write(kryo, output, obj);
+            }
+            Node[] subNodes = node.getSubnode();
+            for(int i = 0;i < 4; ++i){
+                writeQuadTreeNode(kryo, output, subNodes[i]);
+            }
+        }
+    }
+
+    private void writeType(Output output, Type type){
+        output.writeByte((byte)type.id);
+    }
+
+    @Override
+    public Object read(Kryo kryo, Input input, Class aClass) {
+        byte typeID = input.readByte();
+        Type indexType = Type.fromId(typeID);
+        switch (indexType){
+            case QUADTREE:{
+                Quadtree index = new Quadtree();
+                boolean notEmpty = (input.readByte() & 0x01) == 1;
+                if(!notEmpty) return index;
+                int itemSize = input.readInt();
+                List items = new ArrayList();
+                for(int i = 0;i < itemSize; ++i){
+                    items.add(geometrySerde.read(kryo, input, Geometry.class));
+                }
+                index.getRoot().setItems(items);
+                for(int i = 0;i < 4; ++i){
+                    index.getRoot().getSubnode()[i] = readQuadTreeNode(kryo, input);
+                }
+                return index;
+            }
+            case RTREE:{
+                break;
+            }
+            default:{
+                throw new UnsupportedOperationException("can't deserialize spatial index of type" + indexType);
+            }
+        }
+        return null;
+    }
+
+    private Node readQuadTreeNode(Kryo kryo, Input input){
+        boolean notEmpty = (input.readByte() & 0x01) == 1;
+        if(!notEmpty) return null;
+        Envelope envelope = (Envelope) geometrySerde.read(kryo, input, Envelope.class);
+        int level = input.readInt();
+        Node node = new Node(envelope, level);
+        int itemSize = input.readInt();
+        List items = new ArrayList();
+        for(int i = 0;i < itemSize; ++i){
+            items.add(geometrySerde.read(kryo, input, Geometry.class));
+        }
+        node.setItems(items);
+        // read children
+        for(int i = 0;i < 4; ++i){
+            node.getSubnode()[i] = readQuadTreeNode(kryo, input);
+        }
+        return node;
+    }
+}

--- a/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
+++ b/core/src/main/java/org/datasyslab/geospark/serde/GeoSparkKryoRegistrator.java
@@ -1,19 +1,14 @@
 package org.datasyslab.geospark.serde;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.*;
 import com.vividsolutions.jts.index.quadtree.Quadtree;
 import com.vividsolutions.jts.index.strtree.STRtree;
 import org.apache.log4j.Logger;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.datasyslab.geospark.geometryObjects.Circle;
 import org.datasyslab.geospark.geometryObjects.GeometrySerde;
+import org.datasyslab.geospark.geometryObjects.SpatialIndexSerde;
 
 public class GeoSparkKryoRegistrator implements KryoRegistrator {
 
@@ -22,6 +17,7 @@ public class GeoSparkKryoRegistrator implements KryoRegistrator {
     @Override
     public void registerClasses(Kryo kryo) {
         GeometrySerde serializer = new GeometrySerde();
+        SpatialIndexSerde indexSerializer = new SpatialIndexSerde(serializer);
 
         log.info("Registering custom serializers for geometry types");
 
@@ -33,8 +29,9 @@ public class GeoSparkKryoRegistrator implements KryoRegistrator {
         kryo.register(MultiPolygon.class, serializer);
         kryo.register(GeometryCollection.class, serializer);
         kryo.register(Circle.class, serializer);
+        kryo.register(Envelope.class, serializer);
         // TODO: Replace the default serializer with default spatial index serializer
-        kryo.register(Quadtree.class);
-        kryo.register(STRtree.class);
+        kryo.register(Quadtree.class, indexSerializer);
+        kryo.register(STRtree.class, indexSerializer);
     }
 }

--- a/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
@@ -4,10 +4,12 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.index.strtree.STRtree;
 import com.vividsolutions.jts.io.WKTReader;
 import org.junit.Test;
 
@@ -30,32 +32,65 @@ public class SpatialIndexSerdeTest {
 
     @Test
     public void test() throws Exception {
+        //test empty tree
+        testQuadTree(0);
+        testSTRTree(0);
+        // test non-empty tree
+        testQuadTree(10000);
+        testSTRTree(10000);
+    }
+
+    private void testQuadTree(int treeSize) throws Exception {
         SpatialIndexSerde serializer = new SpatialIndexSerde();
         kryo.register(Quadtree.class, serializer);
 
         Output output = new Output(new FileOutputStream("out.dat"));
-        Quadtree tree = generateQuadTree(10000);
-        kryo.writeClassAndObject(output, tree);
+        Quadtree exact = (Quadtree) generateQuadTree(treeSize, Quadtree.class);
+        kryo.writeClassAndObject(output, exact);
         output.close();
 
 
         Input input = new Input(new FileInputStream("out.dat"));
-        Quadtree quadtree = (Quadtree) kryo.readClassAndObject(input);
-        System.out.println(quadtree.queryAll().size());
+        Quadtree expect = (Quadtree) kryo.readClassAndObject(input);
         input.close();
 
-        List sItems = tree.queryAll();
-        List dItems = tree.queryAll();
+        List exactItems = exact.queryAll();
+        List expectItems = expect.queryAll();
 
-        // assert size equals
-        assertEquals(sItems.size(), dItems.size());
         // assert result equals
-        assertThat(sItems, is(dItems));
+        assertThat(exactItems, is(expectItems));
     }
 
-    private Quadtree generateQuadTree(int geomNum){
+    private void testSTRTree(int treeSize) throws Exception {
+        SpatialIndexSerde serializer = new SpatialIndexSerde();
+        kryo.register(STRtree.class, serializer);
+
+        Output output = new Output(new FileOutputStream("out.dat"));
+        STRtree exact = (STRtree) generateQuadTree(treeSize, STRtree.class);
+        kryo.writeClassAndObject(output, exact);
+        output.close();
+
+
+        Input input = new Input(new FileInputStream("out.dat"));
+        STRtree expect = (STRtree) kryo.readClassAndObject(input);
+        input.close();
+
+        // query all points
+        List exactRes = exact.query(new Envelope(-180,180,-90,90));
+        List expectRes = expect.query(new Envelope(-180,180,-90,90));
+
+        // assert size equal and content equal
+        assertThat(exactRes, is(expectRes));
+
+    }
+
+    private SpatialIndex generateQuadTree(int geomNum, Class aClass){
         Random random = new Random();
-        Quadtree quadtree = new Quadtree();
+        SpatialIndex quadtree;
+        // initialize according to class pointed
+        if(aClass == Quadtree.class) quadtree = new Quadtree();
+        else quadtree = new STRtree();
+
         for(int i = 0;i < geomNum; ++i){
             Point point = geometryFactory.createPoint(new Coordinate(
                     random.nextDouble() % 180,
@@ -65,5 +100,7 @@ public class SpatialIndexSerdeTest {
         }
         return quadtree;
     }
+
+
 
 }

--- a/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
@@ -1,0 +1,69 @@
+package org.datasyslab.geospark.geometryObjects;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.index.SpatialIndex;
+import com.vividsolutions.jts.index.quadtree.Quadtree;
+import com.vividsolutions.jts.io.WKTReader;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class SpatialIndexSerdeTest {
+
+    private final Kryo kryo = new Kryo();
+
+    private final WKTReader wktReader = new WKTReader();
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Test
+    public void test() throws Exception {
+        SpatialIndexSerde serializer = new SpatialIndexSerde();
+        kryo.register(Quadtree.class, serializer);
+
+        Output output = new Output(new FileOutputStream("out.dat"));
+        Quadtree tree = generateQuadTree(10000);
+        kryo.writeClassAndObject(output, tree);
+        output.close();
+
+
+        Input input = new Input(new FileInputStream("out.dat"));
+        Quadtree quadtree = (Quadtree) kryo.readClassAndObject(input);
+        System.out.println(quadtree.queryAll().size());
+        input.close();
+
+        List sItems = tree.queryAll();
+        List dItems = tree.queryAll();
+
+        // assert size equals
+        assertEquals(sItems.size(), dItems.size());
+        // assert result equals
+        assertThat(sItems, is(dItems));
+    }
+
+    private Quadtree generateQuadTree(int geomNum){
+        Random random = new Random();
+        Quadtree quadtree = new Quadtree();
+        for(int i = 0;i < geomNum; ++i){
+            Point point = geometryFactory.createPoint(new Coordinate(
+                    random.nextDouble() % 180,
+                    random.nextDouble() % 90
+            ));
+            quadtree.insert(point.getEnvelopeInternal(), point);
+        }
+        return quadtree;
+    }
+
+}

--- a/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/geometryObjects/SpatialIndexSerdeTest.java
@@ -178,8 +178,8 @@ public class SpatialIndexSerdeTest {
 
         for(int i = 0;i < geomNum; ++i){
             Point point = geometryFactory.createPoint(new Coordinate(
-                    random.nextDouble() % 180,
-                    random.nextDouble() % 90
+                    random.nextDouble() * 360 - 180,
+                    random.nextDouble() * 180 - 90
             ));
             quadtree.insert(point.getEnvelopeInternal(), point);
         }


### PR DESCRIPTION
@jiayuasu 
Default kryo serializer can't support its's spatial index since there are some classes without non-arg so I add a SpatialIndexSerde to handle spatial index.

The output size and serialization time is much better than java default serializer and a little bit better than default kryo(I tested  this by adding constructors to its). You can check the work bench of comparing time and size in SpatialIndexSerdeTest.java.

Also, to access to some fields within SpatialIndex objects, I moved JTSPlus dependency to 0.1.4.

