### PR TITLE
Added link to demo paper in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ More details are available here: [GeoSpark Visualization Extension](https://gith
 
 # Publication
 
-Jia Yu, Jinxuan Wu, Mohamed Sarwat. ["A Demonstration of GeoSpark: A Cluster Computing Framework for Processing Big Spatial Data"](). (demo paper) In Proceeding of IEEE International Conference on Data Engineering ICDE 2016, Helsinki, FI, May 2016
+Jia Yu, Jinxuan Wu, Mohamed Sarwat. ["A Demonstration of GeoSpark: A Cluster Computing Framework for Processing Big Spatial Data"](http://www.public.asu.edu/~jiayu2/geospark/publication/GeoSpark_DemoPaper.pdf). (demo paper) In Proceeding of IEEE International Conference on Data Engineering ICDE 2016, Helsinki, FI, May 2016
 
 Jia Yu, Jinxuan Wu, Mohamed Sarwat. ["GeoSpark: A Cluster Computing Framework for Processing Large-Scale Spatial Data"](http://www.public.asu.edu/~jiayu2/geospark/publication/GeoSpark_ShortPaper.pdf). (short paper) In Proceeding of the ACM International Conference on Advances in Geographic Information Systems ACM SIGSPATIAL GIS 2015, Seattle, WA, USA November 2015
 


### PR DESCRIPTION
Link "A Demonstration of GeoSpark: A Cluster Computing Framework for Processing Big Spatial Data" has invalid URL.
Updated link to http://www.public.asu.edu/~jiayu2/geospark/publication/GeoSpark_DemoPaper.pdf