### PR TITLE
Fixed the ST_ConvexHull bug, added ST_Intersection function and turned off the exception in ST_Transform

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
@@ -184,7 +184,7 @@ case class ST_Transform(inputExpressions: Seq[Expression])
 
   override def eval(input: InternalRow): Any =
   {
-    assert(inputExpressions.length>=3&&inputExpressions.length<=4)
+    assert(inputExpressions.length>=3&&inputExpressions.length<=5)
     System.setProperty("org.geotools.referencing.forceXY", "true")
     if (inputExpressions.length>=4)
     {

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
@@ -25,7 +25,6 @@
   */
 package org.apache.spark.sql.geosparksql.expressions
 
-import com.vividsolutions.jts.geom.Polygon
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -36,6 +35,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.datasyslab.geosparksql.utils.GeometrySerializer
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
+import org.opengis.referencing.operation.MathTransform
 
 /**
   * Return the distance between two geometries.
@@ -80,7 +80,7 @@ case class ST_ConvexHull(inputExpressions: Seq[Expression])
   override def eval(input: InternalRow): Any =
   {
     assert(inputExpressions.length==1)
-    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData]).asInstanceOf[Polygon]
+    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     new GenericArrayData(GeometrySerializer.serialize(geometry.convexHull()))
   }
 
@@ -184,18 +184,47 @@ case class ST_Transform(inputExpressions: Seq[Expression])
 
   override def eval(input: InternalRow): Any =
   {
-    assert(inputExpressions.length==3||inputExpressions.length==4)
+    assert(inputExpressions.length>=3&&inputExpressions.length<=4)
     System.setProperty("org.geotools.referencing.forceXY", "true")
-    if (inputExpressions.length==4)
+    if (inputExpressions.length>=4)
     {
       System.setProperty("org.geotools.referencing.forceXY", inputExpressions(3).eval(input).asInstanceOf[Boolean].toString)
     }
     val originalGeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val sourceCRScode = CRS.decode(inputExpressions(1).eval(input).asInstanceOf[UTF8String].toString)
     val targetCRScode = CRS.decode(inputExpressions(2).eval(input).asInstanceOf[UTF8String].toString)
-    val transform = CRS.findMathTransform(sourceCRScode, targetCRScode, false)
+    var transform:MathTransform = null
+    if (inputExpressions.length == 5)
+    {
+      transform = CRS.findMathTransform(sourceCRScode, targetCRScode, inputExpressions(4).eval(input).asInstanceOf[Boolean])
+    }
+    else
+    {
+      transform = CRS.findMathTransform(sourceCRScode, targetCRScode, false)
+    }
     new GenericArrayData(GeometrySerializer.serialize(JTS.transform(originalGeometry, transform)))
+  }
 
+  override def dataType: DataType = new GeometryUDT()
+
+  override def children: Seq[Expression] = inputExpressions
+}
+
+/**
+  * Return the intersection shape of two geometries. The return type is a geometry
+  * @param inputExpressions
+  */
+case class ST_Intersection(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback
+{
+  override def nullable: Boolean = false
+
+  override def eval(input: InternalRow): Any =
+  {
+    assert(inputExpressions.length==2)
+    val leftgeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    val rightgeometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    new GenericArrayData(GeometrySerializer.serialize(leftgeometry.intersection(rightgeometry)))
   }
 
   override def dataType: DataType = new GeometryUDT()

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
@@ -57,6 +57,7 @@ object UdfRegistrator {
     sparkSession.sessionState.functionRegistry.registerFunction("ST_Area", ST_Area)
     sparkSession.sessionState.functionRegistry.registerFunction("ST_Centroid", ST_Centroid)
     sparkSession.sessionState.functionRegistry.registerFunction("ST_Transform", ST_Transform)
+    sparkSession.sessionState.functionRegistry.registerFunction("ST_Intersection", ST_Intersection)
   }
 
   def registerAggregateFunctions(sparkSession: SparkSession): Unit =
@@ -93,6 +94,7 @@ object UdfRegistrator {
     sparkSession.sessionState.functionRegistry.dropFunction("ST_Area")
     sparkSession.sessionState.functionRegistry.dropFunction("ST_Centroid")
     sparkSession.sessionState.functionRegistry.dropFunction("ST_Transform")
+    sparkSession.sessionState.functionRegistry.dropFunction("ST_Intersection")
   }
 
   def dropAggregateFunctions(sparkSession: SparkSession): Unit =

--- a/sql/src/main/scala/org/datasyslab/geosparksql/utils/GeoSparkSQLRegistrator.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/utils/GeoSparkSQLRegistrator.scala
@@ -37,6 +37,13 @@ object GeoSparkSQLRegistrator {
     UdtRegistrator.registerAll()
     UdfRegistrator.registerAll(sqlContext)
   }
+  def registerAll(sparkSession: SparkSession): Unit =
+  {
+    sparkSession.experimental.extraStrategies = JoinQueryDetector :: Nil
+    UdtRegistrator.registerAll()
+    UdfRegistrator.registerAll(sparkSession)
+  }
+
   def dropAll(sparkSession: SparkSession): Unit =
   {
     UdfRegistrator.dropAll(sparkSession)

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -113,7 +113,7 @@ class functionTestScala extends FunSpec with BeforeAndAfterAll {
       var polygonDf = sparkSession.sql("select ST_GeomFromWKT(polygontable._c0) as countyshape from polygontable")
       polygonDf.createOrReplaceTempView("polygondf")
       polygonDf.show()
-      var functionDf = sparkSession.sql("select ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857',true) from polygondf")
+      var functionDf = sparkSession.sql("select ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857',true, false) from polygondf")
       functionDf.show()
     }
 

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -116,5 +116,17 @@ class functionTestScala extends FunSpec with BeforeAndAfterAll {
       var functionDf = sparkSession.sql("select ST_Transform(polygondf.countyshape, 'epsg:4326','epsg:3857',true) from polygondf")
       functionDf.show()
     }
+
+    it("Passed ST_Intersection")
+    {
+      var polygonWktDf = sparkSession.read.format("csv").option("delimiter","\t").option("header","false").load(mixedWktGeometryInputLocation)
+      polygonWktDf.createOrReplaceTempView("polygontable")
+      polygonWktDf.show()
+      var polygonDf = sparkSession.sql("select ST_GeomFromWKT(polygontable._c0) as countyshape from polygontable")
+      polygonDf.createOrReplaceTempView("polygondf")
+      polygonDf.show()
+      var functionDf = sparkSession.sql("select ST_Intersection(polygondf.countyshape, polygondf.countyshape) from polygondf")
+      functionDf.show()
+    }
 	}
 }


### PR DESCRIPTION
This PR will fix the following issue:
1. fix ST_ConvexHull bug: Issue https://github.com/DataSystemsLab/GeoSpark/issues/188
2. add a new function called ST_Intersection which returns the geometrical intersection of two geometries: Issue  https://github.com/DataSystemsLab/GeoSpark/issues/110
3. allow the user to add one more parameter in ST_Transform to turn off the exception in ST_Transform to bypass "Bursa wolf" error: https://github.com/DataSystemsLab/GeoSpark/issues/185
**ST_Transform (A:geometry, SourceCRS:string, TargetCRS:string, [Optional]UseLongitudeLatitudeOrder:Boolean, [Optional]IgnoreException:Boolean)**