### PR TITLE
Support UTF-8 charset in ShapefileReader

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/DbfParseUtil.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/DbfParseUtil.java
@@ -161,11 +161,12 @@ public class DbfParseUtil implements ShapeFileConst {
             FieldDescriptor descriptor = fieldDescriptors.get(i);
             byte[] fldBytes = new byte[descriptor.getFieldLength()];
             buffer.get(fldBytes, 0, fldBytes.length);
-            byte[] attr = fastParse(fldBytes, 0, fldBytes.length).trim().getBytes();
+            String charset = System.getProperty("geospark.global.charset","default");
+            Boolean utf8flag = charset.equalsIgnoreCase("utf8")?true:false;
+            byte[] attr = utf8flag?fldBytes:fastParse(fldBytes, 0, fldBytes.length).trim().getBytes();
             if(i > 0) attributes.append(delimiter, 0, 1);// first attribute doesn't append '\t'
             attributes.append(attr, 0, attr.length);
         }
-        String attrs = attributes.toString();
         return attributes.toString();
 
     }


### PR DESCRIPTION
This PR contains the bugfix to solve the unreadable character in shapefile reader. See Issue https://github.com/DataSystemsLab/GeoSpark/issues/190

If you are working with Arabic, Chinese or Korean character sets in ESRI shapefile, you need to force GeoSpark shapefile reader to use UTF-8 charset.

Add the following line before GeoSpark ShapefileReader:
```
System.setProperty("geospark.global.charset","utf8")
```


