### PR TITLE
Add the support of Apache Spark 2.3.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,8 +2,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
-	<artifactId>geospark</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<artifactId>geospark_2.3</artifactId>
+	<version>1.1.0</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Geospatial extension for Apache Spark</description>
@@ -42,7 +42,7 @@
         <scala.version>2.11.8</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
         <geotools.version>17.0</geotools.version>
-        <spark.version>2.2.1</spark.version>
+        <spark.version>2.3.0</spark.version>
     </properties>
 
     <dependencies>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -2,8 +2,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
-	<artifactId>geospark-sql</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<artifactId>geospark-sql_2.3</artifactId>
+	<version>1.1.0</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>SQL Extension of GeoSpark</description>
@@ -41,7 +41,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.11.8</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
-        <spark.version>2.2.1</spark.version>
+        <spark.version>2.3.0</spark.version>
         <geotools.version>17.0</geotools.version>
 	</properties>
 

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
@@ -25,39 +25,40 @@
   */
 package org.datasyslab.geosparksql.UDF
 
+import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.geosparksql.expressions._
 
 object UdfRegistrator {
   def resigterConstructors(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_PointFromText", ST_PointFromText)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_PolygonFromText", ST_PolygonFromText)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_LineStringFromText", ST_LineStringFromText)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_GeomFromWKT", ST_GeomFromWKT)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_GeomFromGeoJSON", ST_GeomFromGeoJSON)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Circle", ST_Circle)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Point", ST_Point)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_PolygonFromEnvelope", ST_PolygonFromEnvelope)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PointFromText", ST_PointFromText)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PolygonFromText", ST_PolygonFromText)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_LineStringFromText", ST_LineStringFromText)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_GeomFromWKT", ST_GeomFromWKT)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_GeomFromGeoJSON", ST_GeomFromGeoJSON)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Circle", ST_Circle)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Point", ST_Point)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PolygonFromEnvelope", ST_PolygonFromEnvelope)
   }
 
   def registerPredicates(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Contains", ST_Contains)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Intersects", ST_Intersects)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Within", ST_Within)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Contains", ST_Contains)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Intersects", ST_Intersects)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Within", ST_Within)
   }
 
   def registerFunctions(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Distance", ST_Distance)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_ConvexHull", ST_ConvexHull)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Envelope", ST_Envelope)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Length", ST_Length)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Area", ST_Area)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Centroid", ST_Centroid)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Transform", ST_Transform)
-    sparkSession.sessionState.functionRegistry.registerFunction("ST_Intersection", ST_Intersection)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Distance", ST_Distance)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_ConvexHull", ST_ConvexHull)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Envelope", ST_Envelope)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Length", ST_Length)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Area", ST_Area)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Centroid", ST_Centroid)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Transform", ST_Transform)
+    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Intersection", ST_Intersection)
   }
 
   def registerAggregateFunctions(sparkSession: SparkSession): Unit =
@@ -68,39 +69,39 @@ object UdfRegistrator {
 
   def dropConstructors(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_PointFromText")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_PolygonFromText")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_LineStringFromText")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_GeomFromWKT")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_GeomFromGeoJSON")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Circle")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Point")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_PolygonFromEnvelope")
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PointFromText"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PolygonFromText"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_LineStringFromText"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_GeomFromWKT"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_GeomFromGeoJSON"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Circle"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Point"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PolygonFromEnvelope"))
   }
 
   def dropPredicates(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Contains")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Intersects")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Within")
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Contains"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Intersects"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Within"))
   }
 
   def dropFunctions(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Distance")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_ConvexHull")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Envelope")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Length")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Area")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Centroid")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Transform")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Intersection")
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Distance"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_ConvexHull"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Envelope"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Length"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Area"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Centroid"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Transform"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Intersection"))
   }
 
   def dropAggregateFunctions(sparkSession: SparkSession): Unit =
   {
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Envelope_Aggr")
-    sparkSession.sessionState.functionRegistry.dropFunction("ST_Union_Aggr")
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Envelope_Aggr"))
+    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Union_Aggr"))
   }
 
   def registerAll(sqlContext: SQLContext): Unit =

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -2,8 +2,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
-	<artifactId>geospark-viz</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<artifactId>geospark-viz_2.3</artifactId>
+	<version>1.1.0</version>
 	
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Geospatial visualization extension of GeoSpark</description>
@@ -41,7 +41,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.11.8</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
-        <spark.version>2.2.1</spark.version>
+        <spark.version>2.3.0</spark.version>
 	</properties>
 	
 	<dependencies>


### PR DESCRIPTION
This PR makes GeoSparkSQL to support Apache Spark 2.3.0.

The internal UDF APIs in SparkSQL change over versions. Since GeoSparkSQL is put in SparkSQL kernel, we need to change the internal API usage.

This fixed Issue https://github.com/DataSystemsLab/GeoSpark/issues/194