### PR TITLE
Separate the expression catalog and the udf registrator

### DIFF
--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
@@ -1,0 +1,61 @@
+/**
+  * FILE: Catalog
+  * Copyright (c) 2015 - 2018 GeoSpark Development Team
+  *
+  * MIT License
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package org.datasyslab.geosparksql.UDF
+
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
+import org.apache.spark.sql.geosparksql.expressions._
+
+import scala.reflect.runtime.{universe => ru}
+
+object Catalog {
+  val expressions:Seq[FunctionBuilder] = Seq(
+    ST_PointFromText,
+    ST_PolygonFromText,
+    ST_LineStringFromText,
+    ST_GeomFromWKT,
+    ST_GeomFromWKB,
+    ST_GeomFromGeoJSON,
+    ST_Circle,
+    ST_Point,
+    ST_PolygonFromEnvelope,
+    ST_Contains,
+    ST_Intersects,
+    ST_Within,
+    ST_Distance,
+    ST_ConvexHull,
+    ST_Envelope,
+    ST_Length,
+    ST_Area,
+    ST_Centroid,
+    ST_Transform,
+    ST_Intersection
+  )
+
+  val aggregateExpressions:Seq[UserDefinedAggregateFunction] = Seq(
+    new ST_Union_Aggr,
+    new ST_Envelope_Aggr
+  )
+}

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
@@ -26,96 +26,21 @@
 package org.datasyslab.geosparksql.UDF
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.geosparksql.expressions._
 import org.apache.spark.sql.{SQLContext, SparkSession}
 
 object UdfRegistrator {
-  def resigterConstructors(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PointFromText", ST_PointFromText)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PolygonFromText", ST_PolygonFromText)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_LineStringFromText", ST_LineStringFromText)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_GeomFromWKT", ST_GeomFromWKT)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_GeomFromWKB", ST_GeomFromWKB)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_GeomFromGeoJSON", ST_GeomFromGeoJSON)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Circle", ST_Circle)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Point", ST_Point)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_PolygonFromEnvelope", ST_PolygonFromEnvelope)
-  }
-
-  def registerPredicates(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Contains", ST_Contains)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Intersects", ST_Intersects)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Within", ST_Within)
-  }
-
-  def registerFunctions(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Distance", ST_Distance)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_ConvexHull", ST_ConvexHull)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Envelope", ST_Envelope)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Length", ST_Length)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Area", ST_Area)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Centroid", ST_Centroid)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Transform", ST_Transform)
-    sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction("ST_Intersection", ST_Intersection)
-  }
-
-  def registerAggregateFunctions(sparkSession: SparkSession): Unit = {
-    sparkSession.udf.register("ST_Envelope_Aggr", new ST_Envelope_Aggr)
-    sparkSession.udf.register("ST_Union_Aggr", new ST_Union_Aggr)
-  }
-
-  def dropConstructors(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PointFromText"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PolygonFromText"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_LineStringFromText"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_GeomFromWKT"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_GeomFromWKB"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_GeomFromGeoJSON"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Circle"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Point"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_PolygonFromEnvelope"))
-  }
-
-  def dropPredicates(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Contains"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Intersects"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Within"))
-  }
-
-  def dropFunctions(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Distance"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_ConvexHull"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Envelope"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Length"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Area"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Centroid"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Transform"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Intersection"))
-  }
-
-  def dropAggregateFunctions(sparkSession: SparkSession): Unit = {
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Envelope_Aggr"))
-    sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier("ST_Union_Aggr"))
-  }
 
   def registerAll(sqlContext: SQLContext): Unit = {
-    resigterConstructors(sqlContext.sparkSession)
-    registerPredicates(sqlContext.sparkSession)
-    registerFunctions(sqlContext.sparkSession)
-    registerAggregateFunctions(sqlContext.sparkSession)
+    registerAll(sqlContext.sparkSession)
   }
 
   def registerAll(sparkSession: SparkSession): Unit = {
-    resigterConstructors(sparkSession)
-    registerPredicates(sparkSession)
-    registerFunctions(sparkSession)
-    registerAggregateFunctions(sparkSession)
+    Catalog.expressions.foreach(f=>sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction(f.getClass.getSimpleName.dropRight(1),f))
+    Catalog.aggregateExpressions.foreach(f=>sparkSession.udf.register(f.getClass.getSimpleName,f))
   }
 
   def dropAll(sparkSession: SparkSession): Unit = {
-    dropConstructors(sparkSession)
-    dropPredicates(sparkSession)
-    dropFunctions(sparkSession)
-    dropAggregateFunctions(sparkSession)
+    Catalog.expressions.foreach(f=>sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier(f.getClass.getSimpleName.dropRight(1))))
+    Catalog.aggregateExpressions.foreach(f=>sparkSession.sessionState.functionRegistry.dropFunction(FunctionIdentifier(f.getClass.getSimpleName)))
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
No

## What changes were proposed in this PR?
Separate the expression catalog and the udf registrator. Udf registrator used to loop over each single expression in UDF package and use a sentence to register this ST expression.

This led to two problems:
(1) If a patch introduces a new ST function, it is impossible to backport this patch to other SparkSQL branches without resulting in a code conflict.
(2) A huge chunk of redundant code

By having this PR, adding a new ST function can be done through three steps:
1. Add the ST function in org.apache.spark.sql.geosparksql.expressions
2. Add the name of this function in org.datasyslab.geosparksql.UDF.Catalog
3. After accepting the proposed ST function, a GeoSpark committer should use `Git Cherry-Pick` to backport the corresponding commit to all GeoSpark branches such as `GeoSpark-for-Spark-2.1` and `GeoSpark-for-Spark-2.2`

## How was this patch tested?
No need to add new unit tests. This PR has passed the regression test of GeoSparkSQL.

## Did this PR include necessary documentation updates?
No impact on Public APIs