### PR TITLE
Add the empty constructors for 4 typed SpatialRDDs

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/LineStringRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/LineStringRDD.java
@@ -42,6 +42,11 @@ import org.datasyslab.geospark.formatMapper.LineStringFormatMapper;
 public class LineStringRDD
         extends SpatialRDD<LineString>
 {
+    /**
+     * Instantiates a new line string RDD.
+     *
+     */
+    public LineStringRDD(){}
 
     /**
      * Instantiates a new line string RDD.

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/PointRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/PointRDD.java
@@ -47,6 +47,12 @@ public class PointRDD
     /**
      * Instantiates a new point RDD.
      *
+     */
+    public PointRDD(){}
+
+    /**
+     * Instantiates a new point RDD.
+     *
      * @param rawSpatialRDD the raw spatial RDD
      */
     public PointRDD(JavaRDD<Point> rawSpatialRDD)

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/PolygonRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/PolygonRDD.java
@@ -56,6 +56,11 @@ import java.util.Arrays;
 public class PolygonRDD
         extends SpatialRDD<Polygon>
 {
+    /**
+     * Instantiates a new polygon RDD.
+     *
+     */
+    public PolygonRDD(){}
 
     /**
      * Instantiates a new polygon RDD.

--- a/core/src/main/java/org/datasyslab/geospark/spatialRDD/RectangleRDD.java
+++ b/core/src/main/java/org/datasyslab/geospark/spatialRDD/RectangleRDD.java
@@ -43,6 +43,11 @@ import org.datasyslab.geospark.formatMapper.RectangleFormatMapper;
 public class RectangleRDD
         extends SpatialRDD<Polygon>
 {
+    /**
+     * Instantiates a new rectangle RDD.
+     *
+     */
+    public RectangleRDD(){}
 
     /**
      * Instantiates a new rectangle RDD.

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/LineStringRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/LineStringRDDTest.java
@@ -63,9 +63,6 @@ public class LineStringRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-        This test case will load a sample data file and
-     */
     @Test
     public void testConstructor()
             throws Exception
@@ -75,13 +72,24 @@ public class LineStringRDDTest
         assertEquals(inputBoundary, spatialRDD.boundaryEnvelope);
     }
 
+    @Test
+    public void testEmptyConstructor()
+            throws Exception
+    {
+        LineStringRDD spatialRDD = new LineStringRDD(sc, InputLocation, splitter, true, numPartitions, StorageLevel.MEMORY_ONLY());
+        spatialRDD.spatialPartitioning(gridType);
+        spatialRDD.buildIndex(IndexType.RTREE, true);
+        // Create an empty spatialRDD and manually assemble it
+        LineStringRDD spatialRDDcopy = new LineStringRDD();
+        spatialRDDcopy.rawSpatialRDD = spatialRDD.rawSpatialRDD;
+        spatialRDDcopy.indexedRawRDD = spatialRDD.indexedRawRDD;
+        spatialRDDcopy.analyze();
+    }
+
     /**
      * Test hilbert curve spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Hilbert Curve grid can be build correctly.
      */
     @Test
     public void testHilbertCurveSpatialPartitioing()
@@ -99,9 +107,6 @@ public class LineStringRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the STR-Tree grid can be build correctly.
-     */
     @Test
     public void testRTreeSpatialPartitioing()
             throws Exception
@@ -117,9 +122,6 @@ public class LineStringRDDTest
      * Test voronoi spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Voronoi grid can be build correctly.
      */
     @Test
     public void testVoronoiSpatialPartitioing()

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/PointRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/PointRDDTest.java
@@ -62,9 +62,6 @@ public class PointRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-        This test case will load a sample data file and
-     */
     @Test
     public void testConstructor()
             throws Exception
@@ -74,13 +71,23 @@ public class PointRDDTest
         assertEquals(inputBoundary, spatialRDD.boundaryEnvelope);
     }
 
+    @Test
+    public void testEmptyConstructor()
+            throws Exception
+    {
+        PointRDD spatialRDD = new PointRDD(sc, InputLocation, offset, splitter, true, numPartitions, StorageLevel.MEMORY_ONLY());
+        spatialRDD.buildIndex(IndexType.RTREE, false);
+        // Create an empty spatialRDD and manually assemble it
+        PointRDD spatialRDDcopy = new PointRDD();
+        spatialRDDcopy.rawSpatialRDD = spatialRDD.rawSpatialRDD;
+        spatialRDDcopy.indexedRawRDD = spatialRDD.indexedRawRDD;
+        spatialRDDcopy.analyze();
+    }
+
     /**
      * Test equal partitioning.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Hilbert Curve grid can be build correctly.
      */
     @Test
     public void testEqualPartitioning()
@@ -99,9 +106,6 @@ public class PointRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the Hilbert Curve grid can be build correctly.
-     */
     @Test
     public void testHilbertCurveSpatialPartitioing()
             throws Exception
@@ -119,9 +123,6 @@ public class PointRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the STR-Tree grid can be build correctly.
-     */
     @Test
     public void testRTreeSpatialPartitioing()
             throws Exception
@@ -138,9 +139,6 @@ public class PointRDDTest
      * Test voronoi spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Voronoi grid can be build correctly.
      */
     @Test
     public void testVoronoiSpatialPartitioing()

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/PolygonRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/PolygonRDDTest.java
@@ -66,9 +66,6 @@ public class PolygonRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-        This test case will load a sample data file and
-     */
     @Test
     public void testConstructor()
             throws Exception
@@ -76,6 +73,20 @@ public class PolygonRDDTest
         PolygonRDD spatialRDD = new PolygonRDD(sc, InputLocation, splitter, true, numPartitions, StorageLevel.MEMORY_ONLY());
         assertEquals(inputCount, spatialRDD.approximateTotalCount);
         assertEquals(inputBoundary, spatialRDD.boundaryEnvelope);
+    }
+
+    @Test
+    public void testEmptyConstructor()
+            throws Exception
+    {
+        PolygonRDD spatialRDD = new PolygonRDD(sc, InputLocation, splitter, true, numPartitions, StorageLevel.MEMORY_ONLY());
+        spatialRDD.spatialPartitioning(gridType);
+        spatialRDD.buildIndex(IndexType.RTREE, true);
+        // Create an empty spatialRDD and manually assemble it
+        PolygonRDD spatialRDDcopy = new PolygonRDD();
+        spatialRDDcopy.rawSpatialRDD = spatialRDD.rawSpatialRDD;
+        spatialRDDcopy.indexedRawRDD = spatialRDD.indexedRawRDD;
+        spatialRDDcopy.analyze();
     }
 
     @Test
@@ -93,9 +104,6 @@ public class PolygonRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the Hilbert Curve grid can be build correctly.
-     */
     @Test
     public void testHilbertCurveSpatialPartitioing()
             throws Exception
@@ -112,9 +120,6 @@ public class PolygonRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the STR-Tree grid can be build correctly.
-     */
     @Test
     public void testRTreeSpatialPartitioing()
             throws Exception
@@ -130,9 +135,6 @@ public class PolygonRDDTest
      * Test voronoi spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Voronoi grid can be build correctly.
      */
     @Test
     public void testVoronoiSpatialPartitioing()

--- a/core/src/test/java/org/datasyslab/geospark/spatialRDD/RectangleRDDTest.java
+++ b/core/src/test/java/org/datasyslab/geospark/spatialRDD/RectangleRDDTest.java
@@ -63,9 +63,6 @@ public class RectangleRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-        This test case will load a sample data file and
-     */
     @Test
     public void testConstructor()
             throws Exception
@@ -75,13 +72,23 @@ public class RectangleRDDTest
         assertEquals(inputBoundary, spatialRDD.boundaryEnvelope);
     }
 
+    @Test
+    public void testEmptyConstructor()
+            throws Exception
+    {
+        RectangleRDD spatialRDD = new RectangleRDD(sc, InputLocation, offset, splitter, true, numPartitions, StorageLevel.MEMORY_ONLY());
+        spatialRDD.buildIndex(IndexType.RTREE, false);
+        // Create an empty spatialRDD and manually assemble it
+        RectangleRDD spatialRDDcopy = new RectangleRDD();
+        spatialRDDcopy.rawSpatialRDD = spatialRDD.rawSpatialRDD;
+        spatialRDDcopy.indexedRawRDD = spatialRDD.indexedRawRDD;
+        spatialRDDcopy.analyze();
+    }
+
     /**
      * Test hilbert curve spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Hilbert Curve grid can be build correctly.
      */
     @Test
     public void testHilbertCurveSpatialPartitioing()
@@ -100,9 +107,6 @@ public class RectangleRDDTest
      *
      * @throws Exception the exception
      */
-    /*
-     *  This test case test whether the STR-Tree grid can be build correctly.
-     */
     @Test
     public void testRTreeSpatialPartitioing()
             throws Exception
@@ -119,9 +123,6 @@ public class RectangleRDDTest
      * Test voronoi spatial partitioing.
      *
      * @throws Exception the exception
-     */
-    /*
-     *  This test case test whether the Voronoi grid can be build correctly.
      */
     @Test
     public void testVoronoiSpatialPartitioing()

--- a/core/src/test/scala/org/datasyslab/geospark/scalaTest.scala
+++ b/core/src/test/scala/org/datasyslab/geospark/scalaTest.scala
@@ -81,6 +81,13 @@ class scalaTest extends FunSpec with BeforeAndAfterAll {
     val joinQueryPartitioningType = GridType.QUADTREE
     val eachQueryLoopTimes = 1
 
+    it("should pass the empty constructor test") {
+      val objectRDD = new PointRDD(sc, PointRDDInputLocation, PointRDDOffset, PointRDDSplitter, true, StorageLevel.MEMORY_ONLY)
+      val objectRDDcopy = new PointRDD()
+      objectRDDcopy.rawSpatialRDD = objectRDD.rawSpatialRDD
+      objectRDDcopy.analyze()
+    }
+
     it("should pass spatial range query") {
       val objectRDD = new PointRDD(sc, PointRDDInputLocation, PointRDDOffset, PointRDDSplitter, true, StorageLevel.MEMORY_ONLY)
       for (i <- 1 to eachQueryLoopTimes) {


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
No

## What changes were proposed in this PR?
Add the empty constructors for 4 typed SpatialRDDs. So, the users can create an empty SpatialRDD and manually assemble it.

This is especially useful when the users want to load a persisted RDD from disk and assemble a typed SpatialRDD by themselves.

## How was this patch tested?
Passed the regression test. Added four corresponding unit tests: build an empty spatialRDD and manually assemble it.

## Did this PR include necessary documentation updates?
This change will add new APIs. JavaDoc has been added.
