### PR TITLE
DataFrameFactory added

### DIFF
--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/ShapefileReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/ShapefileReader.java
@@ -25,14 +25,7 @@
  */
 package org.datasyslab.geospark.formatMapper.shapefileParser;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.*;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/DbfParseUtil.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/DbfParseUtil.java
@@ -64,6 +64,10 @@ public class DbfParseUtil
         return (float) numRecordRead / (float) numRecord;
     }
 
+    public List<FieldDescriptor> getFieldDescriptors() {
+        return fieldDescriptors;
+    }
+
     /**
      * fieldDescriptors of current .dbf file
      */
@@ -117,7 +121,7 @@ public class DbfParseUtil
             while (nameBytes[zeroId] != 0) { zeroId++; }
             Text fieldName = new Text();
             fieldName.append(nameBytes, 0, zeroId);
-            descriptor.setFiledName(fieldName.toString());
+            descriptor.setFieldName(fieldName.toString());
             // read field type
             descriptor.setFieldType(inputStream.readByte());
             // skip reserved field

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/FieldDescriptor.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/parseUtils/dbf/FieldDescriptor.java
@@ -39,7 +39,7 @@ public class FieldDescriptor
     /**
      * field name.
      */
-    private String filedName = null;
+    private String fieldName = null;
 
     /**
      * field type.
@@ -57,23 +57,23 @@ public class FieldDescriptor
     private byte fieldDecimalCount = 0;
 
     /**
-     * Gets the filed name.
+     * Gets the field name.
      *
-     * @return the filed name
+     * @return the field name
      */
-    public String getFiledName()
+    public String getFieldName()
     {
-        return filedName;
+        return fieldName;
     }
 
     /**
-     * Sets the filed name.
+     * Sets the field name.
      *
-     * @param filedName the new filed name
+     * @param fieldName the new field name
      */
-    public void setFiledName(String filedName)
+    public void setFieldName(String fieldName)
     {
-        this.filedName = filedName;
+        this.fieldName = fieldName;
     }
 
     /**

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/CombineShapeReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/CombineShapeReader.java
@@ -35,11 +35,13 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.log4j.Logger;
+import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.dbf.FieldDescriptor;
 import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp.ShapeType;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.List;
 
 public class CombineShapeReader
         extends RecordReader<ShapeKey, PrimitiveShape>
@@ -114,7 +116,7 @@ public class CombineShapeReader
         CombineFileSplit fileSplit = (CombineFileSplit) split;
         Path[] paths = fileSplit.getPaths();
         for (int i = 0; i < paths.length; ++i) {
-            String suffix = FilenameUtils.getExtension(paths[i].toString());
+            String suffix = FilenameUtils.getExtension(paths[i].toString()).toLowerCase();
             if (suffix.equals(SHP_SUFFIX)) { shpSplit = new FileSplit(paths[i], fileSplit.getOffset(i), fileSplit.getLength(i), fileSplit.getLocations()); }
             else if (suffix.equals(SHX_SUFFIX)) { shxSplit = new FileSplit(paths[i], fileSplit.getOffset(i), fileSplit.getLength(i), fileSplit.getLocations()); }
             else if (suffix.equals(DBF_SUFFIX)) { dbfSplit = new FileSplit(paths[i], fileSplit.getOffset(i), fileSplit.getLength(i), fileSplit.getLocations()); }

--- a/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/CombineShapeReader.java
+++ b/core/src/main/java/org/datasyslab/geospark/formatMapper/shapefileParser/shapes/CombineShapeReader.java
@@ -35,13 +35,11 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.log4j.Logger;
-import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.dbf.FieldDescriptor;
 import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.shp.ShapeType;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
-import java.util.List;
 
 public class CombineShapeReader
         extends RecordReader<ShapeKey, PrimitiveShape>

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -78,6 +78,23 @@ The output will be like this:
 |POLYGON ((-104.56...| 35|011|00933054|35011|    De Baca|      De Baca County| 06| H1|G4020|null| null|null|   A|6015539696|29159492|+34.3592729|-104.3686961|
 |POLYGON ((-96.910...| 31|109|00835876|31109|  Lancaster|    Lancaster County| 06| H1|G4020| 339|30700|null|   A|2169240202|22877180|+40.7835474|-096.6886584|
 ```
+## Load data from shape file directly into DataFrame
+
+Use the following code to create DataFrame from your shape file. If the folder provided in path parameter contains metadata .dbf file, column names will be adjusted accordingly
+```Scala
+import org.datasyslab.geosparksql.utils.DataFrameFactory
+val df = DataFrameFactory.geometryDfFromShapeFile(spark,"/data/nh_polygons")
+df.show
++--------------------+---------+
+|            rddshape|    nh_id|
++--------------------+---------+
+|POLYGON ((-31.265...|267741819|
+|POLYGON ((-31.265...|267741820|
+|POLYGON ((-31.255...|267759817|
+|POLYGON ((-31.255...|267759818|
+|POLYGON ((-31.255...|267759819|
+```
+
 ## Create a Geometry type column
 
 All geometrical operations in GeoSparkSQL are on Geometry type objects. Therefore, before any kind of queries, you need to create a Geometry type column on a DataFrame.

--- a/sql/src/main/scala/org/datasyslab/geosparksql/utils/DataFrameFactory.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/utils/DataFrameFactory.scala
@@ -1,5 +1,27 @@
 package org.datasyslab.geosparksql.utils
+import com.vividsolutions.jts.geom.Geometry
 
-class GeosparkDataframe {
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.datasyslab.geospark.formatMapper.shapefileParser.ShapefileReader
+import org.datasyslab.geospark.formatMapper.shapefileParser.parseUtils.dbf.DbfParseUtil
+import org.datasyslab.geospark.spatialRDD.SpatialRDD
+import scala.collection.JavaConversions._
 
+object DataFrameFactory {
+  def geometryDfFromShapeFile(spark: org.apache.spark.sql.SparkSession, path: String): org.apache.spark.sql.DataFrame ={
+    val srdd = new SpatialRDD[Geometry]
+    srdd.rawSpatialRDD = ShapefileReader.readToGeometryRDD(spark.sparkContext, path)
+    val df = Adapter.toDf(srdd, spark)
+    val inputPath = new Path(path)
+    val fileSys = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val dbfs = fileSys.listStatus(inputPath).filter(i => i.getPath.getName.toLowerCase.contains("dbf"))
+    if(dbfs.length>0) {
+      val inputStream = fileSys.open(dbfs(0).getPath)
+      val dbfParser = new DbfParseUtil
+      dbfParser.parseFileHead(inputStream)
+      val x = dbfParser.getFieldDescriptors
+      val op = "rddshape" +: x.map(x => x.getFieldName).toSeq
+      df.toDF(op: _*)
+    } else df
+  }
 }

--- a/sql/src/main/scala/org/datasyslab/geosparksql/utils/DataFrameFactory.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/utils/DataFrameFactory.scala
@@ -1,0 +1,5 @@
+package org.datasyslab.geosparksql.utils
+
+class GeosparkDataframe {
+
+}


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
No

## What changes were proposed in this PR?
Created new utility object DataFrameFactory. Currently it has only one method called geometryDfFromShapeFile which is reading shape file and returns dataframe directly (no need for the user to go through rdd and Adapter steps). Additionally, if folder containing shapefile does contain .dbf file, column names are read from it and returned DF contains original column names
In the future we could also add methods which instead of returning rddshape column, return Geometry or shape class field.
## How was this patch tested?
Tested on two different shape files with different number of columns. Tests succeeded.

## Did this PR include necessary documentation updates?
Yes, SQL section of the tutorial was updated.
