### PR TITLE
Set PointRDDOffset to 1 when loading arealm-small.csv in the ScalaExample

### DIFF
--- a/core/src/main/scala/org/datasyslab/geospark/showcase/ScalaExample.scala
+++ b/core/src/main/scala/org/datasyslab/geospark/showcase/ScalaExample.scala
@@ -56,7 +56,7 @@ object ScalaExample extends App {
   val PointRDDSplitter = FileDataSplitter.CSV
   val PointRDDIndexType = IndexType.RTREE
   val PointRDDNumPartitions = 5
-  val PointRDDOffset = 0
+  val PointRDDOffset = 1
 
   val PolygonRDDInputLocation = resourceFolder + "primaryroads-polygon.csv"
   val PolygonRDDSplitter = FileDataSplitter.CSV


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

Yes: https://github.com/DataSystemsLab/GeoSpark/issues/235

## What changes were proposed in this PR?

Nothing else than replacing a 0 by a 1 :-)

## How was this patch tested?

Interactively using the spark-shell.
Also, it is now conform to what is written the Scala [test](https://github.com/DataSystemsLab/GeoSpark/blob/master/core/src/test/scala/org/datasyslab/geospark/scalaTest.scala).

## Did this PR include necessary documentation updates?

No.