### PR TITLE
Add ST_PrecisionReduce and add docs for ST_IsValid

### DIFF
--- a/docs/api/sql/GeoSparkSQL-Function.md
+++ b/docs/api/sql/GeoSparkSQL-Function.md
@@ -129,3 +129,34 @@ Spark SQL example:
 SELECT ST_Intersection(polygondf.countyshape, polygondf.countyshape)
 FROM polygondf
 ```
+
+## ST_IsValid
+
+Introduction: Test if a geometry is well formed
+
+Format: `ST_IsValid (A:geometry)`
+
+Since: `v1.2.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_IsValid(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_PrecisionReduce
+
+Introduction: Reduce the decimals places in the coordinates of the geometry to the given number of decimal places. The last decimal place will be rounded.
+
+Format: `ST_PrecisionReduce (A:geometry, B:int)`
+
+Since: `v1.2.0`
+
+Spark SQL example:
+
+```SQL
+SELECT ST_PrecisionReduce(polygondf.countyshape, 9)
+FROM polygondf
+```
+The new coordinates will only have 9 decimal places.

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
@@ -50,7 +50,8 @@ object Catalog {
     ST_Centroid,
     ST_Transform,
     ST_Intersection,
-    ST_IsValid
+    ST_IsValid,
+    ST_PrecisionReduce
   )
 
   val aggregateExpressions:Seq[UserDefinedAggregateFunction] = Seq(

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -154,5 +154,21 @@ class functionTestScala extends FunSpec with BeforeAndAfterAll {
       assert(!testtable.take(1)(0).get(0).asInstanceOf[Boolean])
       assert(testtable.take(1)(0).get(1).asInstanceOf[Boolean])
     }
+
+    it("Passed ST_PrecisionReduce") {
+      var testtable = sparkSession.sql(
+        """
+          |SELECT ST_PrecisionReduce(ST_GeomFromWKT('Point(0.1234567890123456789 0.1234567890123456789)'), 8)
+        """.stripMargin)
+      testtable.show(false)
+      assert(testtable.take(1)(0).get(0).asInstanceOf[Geometry].getCoordinates()(0).x == 0.12345679)
+      testtable = sparkSession.sql(
+        """
+          |SELECT ST_PrecisionReduce(ST_GeomFromWKT('Point(0.1234567890123456789 0.1234567890123456789)'), 11)
+        """.stripMargin)
+      testtable.show(false)
+      assert(testtable.take(1)(0).get(0).asInstanceOf[Geometry].getCoordinates()(0).x == 0.12345678901)
+
+    }
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
Yes, https://github.com/DataSystemsLab/GeoSpark/issues/244
Also add the docs for ST_IsValid https://github.com/DataSystemsLab/GeoSpark/pull/241
## What changes were proposed in this PR?
[SQL] Add a new API called "ST_PrecisionReduce" to reduce the precision of coordinates, in order to avoid "side location conflict"

### ST_PrecisionReduce

Introduction: Reduce the decimals places in the coordinates of the geometry to the given number of decimal places. The last decimal place will be rounded.

Format: `ST_PrecisionReduce (A:geometry, B:int)`

Since: `v1.2.0`

Spark SQL example:

```SQL
SELECT ST_PrecisionReduce(polygondf.countyshape, 9)
FROM polygondf
```
The new coordinates will only have 9 decimal places.

## How was this patch tested?
Pass the new unit test and regression test
## Did this PR include necessary documentation updates?
ST_PrecisionReduce and ST_IsValid docs are added