### PR TITLE
Check for null in ST_IsValid function #288

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
@@ -234,10 +234,13 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
   */
 case class ST_IsValid(inputExpressions: Seq[Expression])
   extends Expression with CodegenFallback {
-  override def nullable: Boolean = false
+  override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
     assert(inputExpressions.length == 1)
+    if (inputExpressions(0).eval(input).asInstanceOf[ArrayData] == null) {
+      return null
+    }
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
     val isvalidop = new IsValidOp(geometry)
     isvalidop.isValid

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -127,6 +127,14 @@ class functionTestScala extends TestBaseScala {
       assert(testtable.take(1)(0).get(1).asInstanceOf[Boolean])
     }
 
+    it("Fixed nullPointerException in ST_IsValid") {
+
+      var testtable=sparkSession.sql(
+        "SELECT ST_IsValid(null)"
+      )
+      assert(testtable.take(1).head.get(0) == null)
+    }
+
     it("Passed ST_PrecisionReduce") {
       var testtable = sparkSession.sql(
         """


### PR DESCRIPTION
Return null if the geometry is null in [ST_IsValid](https://github.com/DataSystemsLab/GeoSpark/blob/de05c0eed36237fd828c24375376403c86457022/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala#L235) function
Define nullable = true
Add a test to cover it

## Is this PR related to a proposed Issue?
#288 
## What changes were proposed in this PR?
Add check for null geometry, and return null when it happens.
This behavior defined by PostGIS for the [ST_IsValid](https://postgis.net/docs/ST_IsValid.html) function docs
## How was this patch tested?
I added a test that query ST_IsValid with null geometry
## Did this PR include necessary documentation updates?
There are no documentation updates