### PR TITLE
Spatial SQL ST_Touches

### DIFF
--- a/docs/api/sql/GeoSparkSQL-Predicate.md
+++ b/docs/api/sql/GeoSparkSQL-Predicate.md
@@ -42,3 +42,18 @@ SELECT *
 FROM pointdf 
 WHERE ST_Within(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
 ```
+
+## ST_Touches
+
+Introduction: Return true if A touches B
+
+Format: `ST_Touches (A:geometry, B:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```SQL
+SELECT * 
+FROM pointdf 
+WHERE ST_Touches(pointdf.arealandmark, ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0))
+```

--- a/docs/api/sql/GeoSparkSQL-Predicate.md
+++ b/docs/api/sql/GeoSparkSQL-Predicate.md
@@ -49,7 +49,7 @@ Introduction: Return true if A touches B
 
 Format: `ST_Touches (A:geometry, B:geometry)`
 
-Since: `v1.0.0`
+Since: `v1.2.0`
 
 Spark SQL example:
 ```SQL

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Predicates.scala
@@ -122,3 +122,33 @@ case class ST_Within(inputExpressions: Seq[Expression])
 
   override def dataType = BooleanType
 }
+
+/**
+  * Test if leftGeometry touches rightGeometry
+  *
+  * @param inputExpressions
+  */
+case class ST_Touches(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback {
+  override def nullable: Boolean = false
+
+  // This is a binary expression
+  assert(inputExpressions.length == 2)
+
+  override def toString: String = s" **${ST_Touches.getClass.getName}**  "
+
+  override def children: Seq[Expression] = inputExpressions
+
+  override def eval(inputRow: InternalRow): Any = {
+    val leftArray = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData]
+    val rightArray = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData]
+
+    val leftGeometry = GeometrySerializer.deserialize(leftArray)
+
+    val rightGeometry = GeometrySerializer.deserialize(rightArray)
+
+    return leftGeometry.touches(rightGeometry)
+  }
+
+  override def dataType = BooleanType
+}

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
@@ -50,7 +50,8 @@ object Catalog {
     ST_Transform,
     ST_Intersection,
     ST_IsValid,
-    ST_PrecisionReduce
+    ST_PrecisionReduce,
+    ST_Touches
   )
 
   val aggregateExpressions:Seq[UserDefinedAggregateFunction] = Seq(

--- a/sql/src/test/scala/org/datasyslab/geosparksql/predicateTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/predicateTestScala.scala
@@ -60,5 +60,15 @@ class predicateTestScala extends TestBaseScala {
       resultDf.show()
       assert(resultDf.count() == 999)
     }
+    it("Passed ST_Touches") {
+      var pointCsvDF = sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(csvPointInputLocation)
+      pointCsvDF.createOrReplaceTempView("pointtable")
+      var pointDf = sparkSession.sql("select ST_Point(cast(pointtable._c0 as Decimal(24,20)), cast(pointtable._c1 as Decimal(24,20))) as arealandmark from pointtable")
+      pointDf.createOrReplaceTempView("pointdf")
+
+      var resultDf = sparkSession.sql("select * from pointdf where ST_Touches(pointdf.arealandmark, ST_PolygonFromEnvelope(0.0,99.0,1.1,101.1))")
+      resultDf.show()
+      assert(resultDf.count() == 1)
+    }
   }
 }


### PR DESCRIPTION

1. Propose a `ST_Touches` feature for Spatial SQL.
2. Since the `JTS geometry` provides the touching operation, I added a testcase which a small polygon touches a line.
3. Added some docs in `GeoSparkSQL-Predicate.md`.
