### PR TITLE
Added ST_Touches option to JoinQueryDetector.scala

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/JoinQueryDetector.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/JoinQueryDetector.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, LessThan, LessThan
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.geosparksql.expressions.{ST_Contains, ST_Distance, ST_Intersects, ST_Within}
+import org.apache.spark.sql.geosparksql.expressions.{ST_Contains, ST_Distance, ST_Intersects, ST_Within, ST_Touches}
 
 /**
   * Plans `RangeJoinExec` for inner joins on spatial relationships ST_Contains(a, b)
@@ -74,6 +74,10 @@ object JoinQueryDetector extends Strategy {
     // ST_WITHIN(a, b) - a is within b
     case Join(left, right, Inner, Some(ST_Within(Seq(leftShape, rightShape)))) =>
       planSpatialJoin(right, left, Seq(rightShape, leftShape), false)
+
+    // ST_Touches(a, b) - a touches b
+    case Join(left, right, Inner, Some(ST_Touches(Seq(leftShape, rightShape)))) =>
+      planSpatialJoin(left, right, Seq(leftShape, rightShape), true)
 
     // ST_Distance(a, b) <= radius consider boundary intersection
     case Join(left, right, Inner, Some(LessThanOrEqual(ST_Distance(Seq(leftShape, rightShape)), radius))) =>


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
No. but related to a review in this [PR](https://github.com/DataSystemsLab/GeoSpark/pull/300#issuecomment-443018927)
## What changes were proposed in this PR?
Added ST_Touches option to JoinQueryDetector.scala in order that spark will leverage GeoSpark RangeJoin algorithm
## How was this patch tested?
Added test in predicateJoinTestScala.scala
## Did this PR include necessary documentation updates?
Not relevant