### PR TITLE
add ST_GeometryType

### DIFF
--- a/docs/api/sql/GeoSparkSQL-Function.md
+++ b/docs/api/sql/GeoSparkSQL-Function.md
@@ -215,3 +215,16 @@ SELECT ST_NPoints(polygondf.countyshape)
 FROM polygondf
 ```
 
+## ST_GeometryType
+
+Introduction: Returns the type of the geometry as a string. EG: 'ST_Linestring', 'ST_Polygon' etc.
+
+Format: `ST_GeometryType (A:geometry)`
+
+Since: `v1.2.1`
+
+Spark SQL example:
+```SQL
+SELECT ST_GeometryType(polygondf.countyshape)
+FROM polygondf
+````

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
@@ -373,3 +373,18 @@ case class ST_AsText(inputExpressions: Seq[Expression])
 
   override def children: Seq[Expression] = inputExpressions
 }
+
+case class ST_GeometryType(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback{
+  override def nullable: Boolean = false
+
+  override def eval(input: InternalRow): Any = {
+    assert(inputExpressions.length == 1)
+    val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
+    UTF8String.fromString(geometry.getGeometryType)
+  }
+
+  override def dataType: DataType = StringType
+
+  override def children: Seq[Expression] = inputExpressions
+}

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/expressions/Functions.scala
@@ -381,7 +381,7 @@ case class ST_GeometryType(inputExpressions: Seq[Expression])
   override def eval(input: InternalRow): Any = {
     assert(inputExpressions.length == 1)
     val geometry = GeometrySerializer.deserialize(inputExpressions(0).eval(input).asInstanceOf[ArrayData])
-    UTF8String.fromString(geometry.getGeometryType)
+    UTF8String.fromString("ST_" + geometry.getGeometryType)
   }
 
   override def dataType: DataType = StringType

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
@@ -51,7 +51,8 @@ object Catalog {
     ST_Overlaps,
 	  ST_Crosses,
     ST_IsSimple,
-    ST_AsText
+    ST_AsText,
+    ST_GeometryType
   )
 
   val aggregateExpressions:Seq[UserDefinedAggregateFunction] = Seq(

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -211,5 +211,10 @@ class functionTestScala extends TestBaseScala {
       assert(test.take(1)(0).get(0).asInstanceOf[Int] == 4)
 
     }
+
+    it("Passed ST_GeometryType"){
+      var test = sparkSession.sql("SELECT ST_GeometryType(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27 29.31,77.29 29.07)'))")
+      assert(test.take(1)(0).get(0).asInstanceOf[String].toUpperCase() == "LINESTRING")
+    }
   }
 }

--- a/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/functionTestScala.scala
@@ -214,7 +214,7 @@ class functionTestScala extends TestBaseScala {
 
     it("Passed ST_GeometryType"){
       var test = sparkSession.sql("SELECT ST_GeometryType(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27 29.31,77.29 29.07)'))")
-      assert(test.take(1)(0).get(0).asInstanceOf[String].toUpperCase() == "LINESTRING")
+      assert(test.take(1)(0).get(0).asInstanceOf[String].toUpperCase() == "ST_LINESTRING")
     }
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
no
## What changes were proposed in this PR?
add sql function `ST_GeometryType`
## How was this patch tested?
`functionTestScala.scala`
## Did this PR include necessary documentation updates?
yes `String ST_GeometryType(geometry)`，return the geometry type