### PR TITLE
Added support for compiling with scala 2.12 and spark 3.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.datasyslab</groupId>
         <artifactId>geospark-parent</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 	<artifactId>geospark</artifactId>
@@ -43,28 +43,14 @@
             <version>0.10.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.vividsolutions</groupId>
-                    <artifactId>jts-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>sernetcdf</artifactId>
-            <version>0.1.0</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -75,22 +61,44 @@
                     <groupId>com.vividsolutions</groupId>
                     <artifactId>jts</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-referencing</artifactId>
             <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
             <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-extension</artifactId>
             <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -101,18 +109,31 @@
                     <groupId>com.vividsolutions</groupId>
                     <artifactId>jts</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
-            <version>2.7.2</version>
+            <version>2.8.2</version>
             <scope>test</scope>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
-
-	<build>
+    <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependencies>
 	<dependency>
 	    <groupId>com.fasterxml.jackson.module</groupId>
-	    <artifactId>jackson-module-scala_2.12</artifactId>
+	    <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
 	    <version>2.10.0</version>
 	</dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.datasyslab</groupId>
 	<artifactId>geospark-parent</artifactId>
-	<version>1.3.1</version>
+	<version>1.4.0</version>
 	<packaging>pom</packaging>
 	<name>geospark-parent</name>
 	<url>http://maven.apache.org</url>
@@ -43,12 +43,17 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.11.8</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
+        <scala.version>2.12.8</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
         <geotools.version>17.0</geotools.version>
-        <spark.version>2.3.0</spark.version>
+        <spark.version>3.0.0-preview2</spark.version>
     </properties>
     <dependencies>
+	<dependency>
+	    <groupId>com.fasterxml.jackson.module</groupId>
+	    <artifactId>jackson-module-scala_2.12</artifactId>
+	    <version>2.10.0</version>
+	</dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.compat.version}</artifactId>
@@ -59,19 +64,67 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+		<exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>2.7.2</version>
+            <version>2.8.2</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.2</version>
+            <version>2.8.2</version>
             <scope>provided</scope>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+	<dependency> 
+	    <groupId>org.apache.hadoop</groupId> 
+	    <artifactId>hadoop-hdfs</artifactId> 
+	    <version>2.8.2</version> 
+	    <exclusions> 
+	        <exclusion> 
+	            <groupId>log4j</groupId> 
+	            <artifactId>log4j</artifactId> 
+	        </exclusion> 
+	        <exclusion> 
+	            <groupId>org.slf4j</groupId> 
+	            <artifactId>slf4j-log4j12</artifactId> 
+	        </exclusion> 
+	    </exclusions> 
+	</dependency> 
+        <dependency>
+            <groupId>org.datasyslab</groupId>
+            <artifactId>sernetcdf</artifactId>
+            <version>0.1.0</version>
         </dependency>
         <!-- Test -->
         <dependency>
@@ -83,7 +136,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.compat.version}</artifactId>
-            <version>2.2.4</version>
+            <version>3.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -98,6 +151,15 @@
             <name>Open Source Geospatial Foundation Repository</name>
             <url>https://download.osgeo.org/webdav/geotools/</url>
         </repository>
+	<repository>
+	    <id>osgeo-alt</id>
+	    <url>https://repo.osgeo.org/repository/release/</url>
+	</repository>
+	<repository>
+	    <id>geomajas</id>
+	    <name>Geomajas Maven Repository</name>
+	    <url>http://maven.geomajas.org/(http://maven.geomajas.org/)</url>
+	</repository>
     </repositories>
     <build>
         <pluginManagement>
@@ -134,12 +196,7 @@
                                 </args>
                             </configuration>
                         </execution>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>doc-jar</goal>
-                            </goals>
-                        </execution>
+                        
                     </executions>
                 </plugin>
                 <plugin>
@@ -200,6 +257,12 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.datasyslab:sernetcdf</artifact>
+                                    <excludes>
+                                        <exclude>com/fasterxml/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
             <groupId>org.datasyslab</groupId>
             <artifactId>sernetcdf</artifactId>
             <version>0.1.0</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Test -->
         <dependency>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -21,10 +21,10 @@
     <parent>
         <groupId>org.datasyslab</groupId>
         <artifactId>geospark-parent</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>geospark-sql_2.3</artifactId>
+	<artifactId>geospark-sql_3.0</artifactId>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>SQL Extension of GeoSpark</description>
@@ -43,12 +43,32 @@
             <artifactId>spark-sql_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 	<build>

--- a/sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/JoinQueryDetector.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/JoinQueryDetector.scala
@@ -55,39 +55,39 @@ object JoinQueryDetector extends Strategy {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
 
     // ST_Contains(a, b) - a contains b
-    case Join(left, right, Inner, Some(ST_Contains(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Contains(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(left, right, Seq(leftShape, rightShape), false)
 
     // ST_Intersects(a, b) - a intersects b
-    case Join(left, right, Inner, Some(ST_Intersects(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Intersects(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(left, right, Seq(leftShape, rightShape), true)
 
     // ST_WITHIN(a, b) - a is within b
-    case Join(left, right, Inner, Some(ST_Within(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Within(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(right, left, Seq(rightShape, leftShape), false)
       
      // ST_Overlaps(a, b) - a overlaps b
-    case Join(left, right, Inner, Some(ST_Overlaps(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Overlaps(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(right, left, Seq(rightShape, leftShape), false)
 
     // ST_Touches(a, b) - a touches b
-    case Join(left, right, Inner, Some(ST_Touches(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Touches(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(left, right, Seq(leftShape, rightShape), true)
 
     // ST_Distance(a, b) <= radius consider boundary intersection
-    case Join(left, right, Inner, Some(LessThanOrEqual(ST_Distance(Seq(leftShape, rightShape)), radius))) =>
+    case Join(left, right, Inner, Some(LessThanOrEqual(ST_Distance(Seq(leftShape, rightShape)), radius)), _) =>
       planDistanceJoin(left, right, Seq(leftShape, rightShape), radius, true)
 
     // ST_Distance(a, b) < radius don't consider boundary intersection
-    case Join(left, right, Inner, Some(LessThan(ST_Distance(Seq(leftShape, rightShape)), radius))) =>
+    case Join(left, right, Inner, Some(LessThan(ST_Distance(Seq(leftShape, rightShape)), radius)), _) =>
       planDistanceJoin(left, right, Seq(leftShape, rightShape), radius, false)
     
     // ST_Equals(a, b) - a is equal to b
-    case Join(left, right, Inner, Some(ST_Equals(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Equals(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(left, right, Seq(leftShape, rightShape), false)
     
     // ST_Crosses(a, b) - a crosses b
-    case Join(left, right, Inner, Some(ST_Crosses(Seq(leftShape, rightShape)))) =>
+    case Join(left, right, Inner, Some(ST_Crosses(Seq(leftShape, rightShape))), _) =>
       planSpatialJoin(right, left, Seq(rightShape, leftShape), false)
 
     case _ =>

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -21,10 +21,10 @@
     <parent>
         <groupId>org.datasyslab</groupId>
         <artifactId>geospark-parent</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>geospark-viz_2.3</artifactId>
+	<artifactId>geospark-viz_3.0</artifactId>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Geospatial visualization extension of GeoSpark</description>
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.datasyslab</groupId>
-            <artifactId>geospark-sql_2.3</artifactId>
+            <artifactId>geospark-sql_3.0</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -49,6 +49,12 @@
             <artifactId>spark-sql_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 		<dependency>
   			<groupId>org.datasyslab</groupId>
@@ -73,6 +79,10 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -67,12 +67,6 @@
             <version>1.0.0</version>
         </dependency>
         <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>sernetcdf</artifactId>
-            <version>0.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>1.7.4</version>


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
Yes: [#340]( https://github.com/DataSystemsLab/GeoSpark/issues/340), but this PR is for spark 3.0 instead of spark 2.4

## What changes were proposed in this PR?
Support for compiling with scala 2.12 and spark 3.0

## How was this patch tested?
mvn clean install

## Did this PR include necessary documentation updates?
No api changes made,  just dependency updates, dependency exclusions, a shading exclusion, and very minor changes to:
[JoinQueryDetector.scala](sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/JoinQueryDetector.scala)
and
[TraitJoinQueryExec.scala](sql/src/main/scala/org/apache/spark/sql/geosparksql/strategy/join/TraitJoinQueryExec.scala)
to accommodate changes in spark 3.0