### PR TITLE
Fix minor issues in the visualization tutorial

### DIFF
--- a/docs/tutorial/viz.md
+++ b/docs/tutorial/viz.md
@@ -115,7 +115,7 @@ Run the following command to assign colors for pixels based on their weights.
 
 ```sql
 CREATE OR REPLACE TEMP VIEW pixelaggregates AS
-SELECT ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates)) as color
+SELECT pixel, ST_Colorize(weight, (SELECT max(weight) FROM pixelaggregates)) as color
 FROM pixelaggregates
 ```
 
@@ -139,7 +139,7 @@ This DataFrame will contain a Image type column which has only one image.
 Fetch the image from the previous DataFrame
 
 ```
-var image = spark.table("images").take(1)(0)(0).asInstanceOf[ImageSerializableWrapper].getImage
+var image = sparkSession.table("images").take(1)(0)(0).asInstanceOf[ImageSerializableWrapper].getImage
 ```
 
 Use GeoSparkViz ImageGenerator to store this image on disk.


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

No

## What changes were proposed in this PR?

This PR fixes an example query and a variable name in the visualization
tutorial, so that the succeeding query works and the variable names are
consistent in the same document, respectively.

## How was this patch tested?

Ran `mkdocs serve` locally and confirmed the modified queries and
snippets worked by copy-pasting from the generated document.

## Did this PR include necessary documentation updates?

Yes (it's a fix for the documentation itself)