### PR TITLE
Fix test failures of the sql and viz modules

### DIFF
--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -54,6 +54,42 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.compat.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--The following GeoTools dependencies use GNU Lesser General Public License and thus are excluded from the binary distribution-->
+        <!-- Users have to include them by themselves manually -->
+        <!-- See https://www.apache.org/legal/resolved.html#category-x -->
+        <!-- See https://github.com/geotools/geotools#license -->
+        <!--for CRS transformation-->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--for CRS transformation-->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 	<build>
         <sourceDirectory>src/main/scala</sourceDirectory>

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -76,6 +76,36 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--The following GeoTools dependencies use GNU Lesser General Public License and thus are excluded from the binary distribution-->
+        <!-- Users have to include them by themselves manually -->
+        <!-- See https://www.apache.org/legal/resolved.html#category-x -->
+        <!-- See https://github.com/geotools/geotools#license -->
+        <!--for CRS transformation-->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--for CRS transformation-->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 	</dependencies>
 	<build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/viz/src/test/java/org/datasyslab/geosparkviz/ChoroplethmapTest.java
+++ b/viz/src/test/java/org/datasyslab/geosparkviz/ChoroplethmapTest.java
@@ -116,6 +116,7 @@ public class ChoroplethmapTest
         ImageGenerator imageGenerator = new ImageGenerator();
         imageGenerator.SaveRasterImageAsLocalFile(rasterOverlayOperator.backRasterImage, "./target/choroplethmap/PolygonRDD-combined", ImageType.GIF);
 
+        /*
         visualizationOperator = new ChoroplethMap(1000, 600, USMainLandBoundary, false, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.RED, true);
         visualizationOperator.Visualize(sparkContext, joinResult);
@@ -133,5 +134,6 @@ public class ChoroplethmapTest
 
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(vectorOverlayOperator.backVectorImage, "./target/choroplethmap/PolygonRDD-combined", ImageType.SVG);
+        */
     }
 }

--- a/viz/src/test/java/org/datasyslab/geosparkviz/ScatterplotTest.java
+++ b/viz/src/test/java/org/datasyslab/geosparkviz/ScatterplotTest.java
@@ -95,11 +95,13 @@ public class ScatterplotTest
         ImageGenerator imageGenerator = new ImageGenerator();
         imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.rasterImage, "./target/scatterplot/PointRDD", ImageType.PNG);
 
+        /*
         visualizationOperator = new ScatterPlot(1000, 600, USMainLandBoundary, false, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.GREEN, true);
         visualizationOperator.Visualize(sparkContext, spatialRDD);
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.vectorImage, "./target/scatterplot/PointRDD", ImageType.SVG);
+        */
     }
 
     /**
@@ -141,11 +143,13 @@ public class ScatterplotTest
 
         imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.distributedRasterImage, scatterPlotOutputPath + "PointRDD-parallel-raster", ImageType.PNG);
 
+        /*
         visualizationOperator = new ScatterPlot(1000, 600, USMainLandBoundary, false, -1, -1, true, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.GREEN, true);
         visualizationOperator.Visualize(sparkContext, spatialRDD);
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.distributedVectorImage, scatterPlotOutputPath + "PointRDD-parallel-vector", ImageType.SVG);
+        */
     }
 
     /**
@@ -164,11 +168,13 @@ public class ScatterplotTest
         ImageGenerator imageGenerator = new ImageGenerator();
         imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.rasterImage, "./target/scatterplot/RectangleRDD", ImageType.GIF);
 
+        /*
         visualizationOperator = new ScatterPlot(1000, 600, USMainLandBoundary, false, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.RED, true);
         visualizationOperator.Visualize(sparkContext, spatialRDD);
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.vectorImage, "./target/scatterplot/RectangleRDD", ImageType.SVG);
+        */
     }
 
     /**
@@ -188,11 +194,13 @@ public class ScatterplotTest
         ImageGenerator imageGenerator = new ImageGenerator();
         imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.rasterImage, "./target/scatterplot/PolygonRDD", ImageType.GIF);
 
+        /*
         visualizationOperator = new ScatterPlot(1000, 600, USMainLandBoundary, false, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.GREEN, true);
         visualizationOperator.Visualize(sparkContext, spatialRDD);
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.vectorImage, "./target/scatterplot/PolygonRDD", ImageType.SVG);
+        */
     }
 
     /**
@@ -214,10 +222,12 @@ public class ScatterplotTest
         ImageGenerator imageGenerator = new ImageGenerator();
         imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.rasterImage, "./target/scatterplot/LineStringRDD", ImageType.GIF);
 
+        /*
         visualizationOperator = new ScatterPlot(resolutionX, resolutionY, USMainLandBoundary, false, true);
         visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.GREEN, true);
         visualizationOperator.Visualize(sparkContext, spatialRDD);
         imageGenerator = new ImageGenerator();
         imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.vectorImage, "./target/scatterplot/LineStringRDD", ImageType.SVG);
+        */
     }
 }

--- a/viz/src/test/scala/org/datasyslab/geosparkviz/rdd/scalaTest.scala
+++ b/viz/src/test/scala/org/datasyslab/geosparkviz/rdd/scalaTest.scala
@@ -110,6 +110,7 @@ class scalaTest extends FunSpec with BeforeAndAfterAll{
       visualizationOperator.Visualize(sparkContext, spatialRDD)
       var imageGenerator = new ImageGenerator
       imageGenerator.SaveRasterImageAsLocalFile(visualizationOperator.rasterImage, scatterPlotOutputPath, ImageType.PNG)
+      /*
       visualizationOperator = new ScatterPlot(1000, 600, USMainLandBoundary, false, -1, -1, false, true)
       visualizationOperator.CustomizeColor(255, 255, 255, 255, Color.GREEN, true)
       visualizationOperator.Visualize(sparkContext, spatialRDD)
@@ -120,6 +121,7 @@ class scalaTest extends FunSpec with BeforeAndAfterAll{
       visualizationOperator.Visualize(sparkContext, spatialRDD)
       imageGenerator = new ImageGenerator
       imageGenerator.SaveVectorImageAsLocalFile(visualizationOperator.distributedVectorImage, scatterPlotOutputPath + "-distributed", ImageType.SVG)
+      */
       true
     }
 


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

No

## What changes were proposed in this PR?

Currently, tests for the sql and viz modules are failing, as follows:
https://travis-ci.org/github/DataSystemsLab/GeoSpark/builds/714265634#L697

To fix it, this PR:

* Added required libraries as dependencies.
  
  - Hive dependency is required only for the test, so its scope is limited as 'test'.

  - The sql and viz modules also require some GeoTools dependencies
    (without them, they fail with `NoSuchAuthorityCodeException`),
    so they are added with the 'provided' scope, as the core module.

* Disabled tests for generating SVG, because that feature was removed by the commit 4baed9184d9178e123c3290cf30999f115c3bb53.

Regarding the latter point, I think we can revive this feature in the future
using another SVG library such as Apache Batik instead of JFreeSVG,
so I just commented them out rather than deleted.

## How was this patch tested?

I ran `mvn test` locally and confirmed all tests succeeded.

## Did this PR include necessary documentation updates?

No