### PR TITLE
Fix Python compare_versions function

### DIFF
--- a/python/geospark/core/jvm/config.py
+++ b/python/geospark/core/jvm/config.py
@@ -11,7 +11,7 @@ FORMAT = '%(asctime) %(message)s'
 logging.basicConfig(format=FORMAT)
 
 
-def compare_versions(version_a: str, version_b: str) -> bool:
+def is_greater_or_equal_version(version_a: str, version_b: str) -> bool:
     if all([version_b, version_a]):
         version_numbers = version_a.split("."), version_b.split(".")
         if any([version[0] == "" for version in version_numbers]):
@@ -31,7 +31,7 @@ def since(version: str):
     def wrapper(function):
         def applier(*args, **kwargs):
             geo_spark_version = GeoSparkMeta.version
-            if not compare_versions(geo_spark_version, version):
+            if not is_greater_or_equal_version(geo_spark_version, version):
                 logging.warning(f"This function is not available for {geo_spark_version}, "
                                 f"please use version higher than {version}")
                 raise AttributeError(f"Not available before {version} geospark version")
@@ -98,8 +98,8 @@ class GeoSparkMeta:
 
 
 if __name__ == "__main__":
-    assert not compare_versions("1.1.5", "1.2.0")
-    assert compare_versions("1.2.0", "1.1.5")
-    assert compare_versions("1.3.5", "1.2.0")
-    assert not compare_versions("", "1.2.0")
-    assert not compare_versions("1.3.5", "")
+    assert not is_greater_or_equal_version("1.1.5", "1.2.0")
+    assert is_greater_or_equal_version("1.2.0", "1.1.5")
+    assert is_greater_or_equal_version("1.3.5", "1.2.0")
+    assert not is_greater_or_equal_version("", "1.2.0")
+    assert not is_greater_or_equal_version("1.3.5", "")

--- a/python/geospark/core/jvm/config.py
+++ b/python/geospark/core/jvm/config.py
@@ -18,7 +18,9 @@ def compare_versions(version_a: str, version_b: str) -> bool:
             return False
 
         for ver_a, ver_b in zip(*version_numbers):
-            if int(ver_a) < int(ver_b):
+            if int(ver_a) > int(ver_b):
+                return True
+            elif int(ver_a) < int(ver_b):
                 return False
     else:
         return False
@@ -96,7 +98,8 @@ class GeoSparkMeta:
 
 
 if __name__ == "__main__":
-    assert not compare_versions("1.2.0", "1.1.5")
+    assert not compare_versions("1.1.5", "1.2.0")
+    assert compare_versions("1.2.0", "1.1.5")
     assert compare_versions("1.3.5", "1.2.0")
     assert not compare_versions("", "1.2.0")
     assert not compare_versions("1.3.5", "")

--- a/python/tests/format_mapper/test_geo_json_reader.py
+++ b/python/tests/format_mapper/test_geo_json_reader.py
@@ -2,7 +2,7 @@ import os
 
 import pyspark
 
-from geospark.core.jvm.config import compare_versions, GeoSparkMeta
+from geospark.core.jvm.config import is_greater_or_equal_version, GeoSparkMeta
 
 from geospark.core.formatMapper.geo_json_reader import GeoJsonReader
 from tests.test_base import TestBase
@@ -18,7 +18,7 @@ geo_json_with_invalid_geom_with_feature_property = os.path.join(tests_path, "res
 class TestGeoJsonReader(TestBase):
 
     def test_read_to_geometry_rdd(self):
-        if compare_versions(GeoSparkMeta.version, "1.2.0"):
+        if is_greater_or_equal_version(GeoSparkMeta.version, "1.2.0"):
             geo_json_rdd = GeoJsonReader.readToGeometryRDD(
                 self.sc,
                 geo_json_geom_with_feature_property
@@ -34,7 +34,7 @@ class TestGeoJsonReader(TestBase):
             assert geo_json_rdd.rawSpatialRDD.count() == 10
 
     def test_read_to_valid_geometry_rdd(self):
-        if compare_versions(GeoSparkMeta.version, "1.2.0"):
+        if is_greater_or_equal_version(GeoSparkMeta.version, "1.2.0"):
             geo_json_rdd = GeoJsonReader.readToGeometryRDD(
                 self.sc,
                 geo_json_geom_with_feature_property,
@@ -69,7 +69,7 @@ class TestGeoJsonReader(TestBase):
             assert geo_json_rdd.rawSpatialRDD.count() == 3
 
     def test_read_to_include_id_rdd(self):
-        if compare_versions(GeoSparkMeta.version, "1.2.0"):
+        if is_greater_or_equal_version(GeoSparkMeta.version, "1.2.0"):
             geo_json_rdd = GeoJsonReader.readToGeometryRDD(
                 self.sc,
                 geo_json_contains_id,
@@ -90,7 +90,7 @@ class TestGeoJsonReader(TestBase):
                 assert geo_json_rdd.fieldNames.__len__() == 3
 
     def test_read_to_geometry_rdd_invalid_syntax(self):
-        if compare_versions(GeoSparkMeta.version, "1.2.0"):
+        if is_greater_or_equal_version(GeoSparkMeta.version, "1.2.0"):
             geojson_rdd = GeoJsonReader.readToGeometryRDD(
                 self.sc,
                 geo_json_with_invalid_geom_with_feature_property,

--- a/python/tests/format_mapper/test_shapefile_reader.py
+++ b/python/tests/format_mapper/test_shapefile_reader.py
@@ -1,7 +1,7 @@
 import os
 
 from geospark.core.geom.envelope import Envelope
-from geospark.core.jvm.config import GeoSparkMeta, compare_versions
+from geospark.core.jvm.config import GeoSparkMeta, is_greater_or_equal_version
 from geospark.core.spatialOperator import RangeQuery
 from tests.tools import tests_path
 from geospark.core.formatMapper.shapefileParser import ShapefileReader
@@ -18,7 +18,7 @@ class TestShapeFileReader(TestBase):
             sc=self.sc, inputPath=undefined_type_shape_location
         )
 
-        if compare_versions(GeoSparkMeta.version, "1.2.0"):
+        if is_greater_or_equal_version(GeoSparkMeta.version, "1.2.0"):
             assert shape_rdd.fieldNames == ['LGA_CODE16', 'LGA_NAME16', 'STE_CODE16', 'STE_NAME16', 'AREASQKM16']
         assert shape_rdd.getRawSpatialRDD().count() == 545
 

--- a/python/tests/sql/test_adapter.py
+++ b/python/tests/sql/test_adapter.py
@@ -12,7 +12,7 @@ from geospark.core.SpatialRDD.spatial_rdd import SpatialRDD
 from geospark.core.enums import FileDataSplitter, GridType, IndexType
 from geospark.core.formatMapper.shapefileParser.shape_file_reader import ShapefileReader
 from geospark.core.geom.envelope import Envelope
-from geospark.core.jvm.config import compare_versions
+from geospark.core.jvm.config import is_greater_or_equal_version
 from geospark.core.spatialOperator import JoinQuery
 from geospark.utils.adapter import Adapter
 from tests.data import geojson_input_location, shape_file_with_missing_trailing_input_location, \
@@ -42,7 +42,7 @@ class TestAdapter(TestBase):
         spatial_rdd.analyze()
         Adapter.toDf(spatial_rdd, self.spark).show()
 
-    @pytest.mark.skipif(compare_versions(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
     def test_read_csv_point_into_spatial_rdd_by_passing_coordinates(self):
         df = self.spark.read.format("csv").\
             option("delimiter", ",").\
@@ -64,7 +64,7 @@ class TestAdapter(TestBase):
         assert (Adapter.toDf(spatial_rdd, self.spark).columns.__len__() == 1)
         Adapter.toDf(spatial_rdd, self.spark).show()
 
-    @pytest.mark.skipif(compare_versions(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
     def test_read_csv_point_into_spatial_rdd_with_unique_id_by_passing_coordinates(self):
         df = self.spark.read.format("csv").\
             option("delimiter", ",").\
@@ -252,7 +252,7 @@ class TestAdapter(TestBase):
 
         return spatial_df
 
-    @pytest.mark.skipif(compare_versions(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
     def test_to_rdd_from_dataframe(self):
         spatial_df = self._create_spatial_point_table()
 
@@ -287,7 +287,7 @@ class TestAdapter(TestBase):
         assert spatial_rdd.approximateTotalCount == 121960
         assert spatial_rdd.boundaryEnvelope == Envelope(-179.147236, 179.475569, -14.548699, 71.35513400000001)
 
-    @pytest.mark.skipif(compare_versions(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version(version, "1.3.0"), reason="Depreciated after spark 1.2.0")
     def test_to_spatial_rdd_df_geom_column_id(self):
         df = self.spark.read.\
             format("csv").\

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -11,7 +11,7 @@ from shapely import wkt
 from shapely.wkt import loads
 
 from geospark import version
-from geospark.core.jvm.config import compare_versions
+from geospark.core.jvm.config import is_greater_or_equal_version
 from geospark.sql.types import GeometryType
 from tests.data import mixed_wkt_geometry_input_location, mixed_wkt_geometry_input_location_1
 from tests.sql.resource.sample_data import create_simple_polygons, create_sample_points, create_simple_polygons_df, \
@@ -228,7 +228,7 @@ class TestPredicateJoin(TestBase):
         wkt_df = self.spark.sql("select ST_AsText(countyshape) as wkt from polygondf")
         assert polygon_df.take(1)[0]["countyshape"].wkt == loads(wkt_df.take(1)[0]["wkt"]).wkt
 
-    @pytest.mark.skipif(compare_versions("1.2.0", version), reason="requires Geospark version above 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.2.0", version), reason="requires Geospark version above 1.2.0")
     def test_st_n_points(self):
         if pyspark.version.__version__[:3] == "2.2":
             pass
@@ -236,7 +236,7 @@ class TestPredicateJoin(TestBase):
             test = self.spark.sql("SELECT ST_NPoints(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27 29.31,77.29 29.07)'))")
             assert test.take(1)[0][0] == 4
 
-    @pytest.mark.skipif(compare_versions("1.2.0", version), reason="requires Geospark version above 1.2.0")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.2.0", version), reason="requires Geospark version above 1.2.0")
     def test_st_geometry_type(self):
         if pyspark.version.__version__[:3] == "2.2":
             pass
@@ -244,7 +244,7 @@ class TestPredicateJoin(TestBase):
             test = self.spark.sql("SELECT ST_GeometryType(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27 29.31,77.29 29.07)'))")
             assert test.take(1)[0][0].upper() == "ST_LINESTRING"
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_azimuth(self):
         sample_points = create_sample_points(20)
         sample_pair_points = [[el, sample_points[1]] for el in sample_points]
@@ -274,7 +274,7 @@ class TestPredicateJoin(TestBase):
         azimuths = [[azimuth1 * 180 / math.pi, azimuth2 * 180 / math.pi] for azimuth1, azimuth2 in azimuth]
         assert azimuths[0] == [42.27368900609373, 222.27368900609372]
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_x(self):
         point_df = create_sample_points_df(self.spark, 5)
         polygon_df = create_sample_polygons_df(self.spark, 5)
@@ -293,7 +293,7 @@ class TestPredicateJoin(TestBase):
 
         assert(not polygons.count())
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_y(self):
         point_df = create_sample_points_df(self.spark, 5)
         polygon_df = create_sample_polygons_df(self.spark, 5)
@@ -312,7 +312,7 @@ class TestPredicateJoin(TestBase):
 
         assert(not polygons.count())
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_start_point(self):
 
         point_df = create_sample_points_df(self.spark, 5)
@@ -339,7 +339,7 @@ class TestPredicateJoin(TestBase):
 
         assert(not polygons.count())
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_end_point(self):
         linestring_dataframe = create_sample_lines_df(self.spark, 5)
         other_geometry_dataframe = create_sample_points_df(self.spark, 5). \
@@ -363,7 +363,7 @@ class TestPredicateJoin(TestBase):
 
         assert(empty_dataframe.count() == 0)
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_boundary(self):
         wkt_list = [
             "LINESTRING(1 1,0 0, -1 1)",
@@ -392,7 +392,7 @@ class TestPredicateJoin(TestBase):
             "LINESTRING (1 1, 0 0, -1 1, 1 1)"
         ])
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_exterior_ring(self):
         polygon_df = create_simple_polygons_df(self.spark, 5)
         additional_wkt = "POLYGON((0 0 1, 1 1 1, 1 2 1, 1 1 1, 0 0 1))"
@@ -413,7 +413,7 @@ class TestPredicateJoin(TestBase):
 
         assert(not empty_df.count())
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_geometry_n(self):
         data_frame = self.__wkt_list_to_data_frame(["MULTIPOINT((1 2), (3 4), (5 6), (8 9))"])
         wkts = [data_frame.selectExpr(f"ST_GeometryN(geom, {i}) as geom").selectExpr("st_asText(geom)").collect()[0][0]
@@ -421,7 +421,7 @@ class TestPredicateJoin(TestBase):
 
         assert(wkts == ["POINT (1 2)", "POINT (3 4)", "POINT (5 6)", "POINT (8 9)"])
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_interior_ring_n(self):
         polygon_df = self.__wkt_list_to_data_frame(
             ["POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))"]
@@ -439,7 +439,7 @@ class TestPredicateJoin(TestBase):
                           "LINESTRING (1 3, 2 3, 2 4, 1 4, 1 3)",
                           "LINESTRING (3 3, 4 3, 4 4, 3 4, 3 3)"])
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_dumps(self):
         expected_geometries = [
             "POINT (21 52)", "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
@@ -477,7 +477,7 @@ class TestPredicateJoin(TestBase):
 
         assert([geom_row[0] for geom_row in collected_geometries] == expected_geometries)
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_dump_points(self):
         expected_points = [
             "POINT (-112.506968 45.98186)",
@@ -501,7 +501,7 @@ class TestPredicateJoin(TestBase):
         collected_points = [geom_row[0] for geom_row in dumped_points.selectExpr("ST_AsText(geom)").collect()]
         assert(collected_points == expected_points)
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_is_closed(self):
         expected_result = [
             [1, True],
@@ -533,7 +533,7 @@ class TestPredicateJoin(TestBase):
         is_closed_collected = [[*row] for row in is_closed]
         assert(is_closed_collected == expected_result)
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_num_interior_ring(self):
         geometries = [
             (1, "Point(21 52)"),
@@ -554,7 +554,7 @@ class TestPredicateJoin(TestBase):
         collected_interior_rings = [[*row] for row in number_of_interior_rings.filter("num is not null").collect()]
         assert(collected_interior_rings == [[2, 0], [11, 1]])
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_add_point(self):
         geometry = [
             ("Point(21 52)", "Point(21 52)"),
@@ -576,7 +576,7 @@ class TestPredicateJoin(TestBase):
         ]
         assert(collected_geometries[0] == "LINESTRING (0 0, 1 1, 1 0, 21 52)")
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_remove_point(self):
         result_and_expected = [
             [self.calculate_st_remove("Linestring(0 0, 1 1, 1 0, 0 0)", 0), "LINESTRING (1 1, 1 0, 0 0)"],
@@ -592,7 +592,7 @@ class TestPredicateJoin(TestBase):
         for actual, expected in result_and_expected:
             assert(actual == expected)
 
-    @pytest.mark.skipif(compare_versions("1.3.1", version), reason="requires Geospark version above 1.3.1")
+    @pytest.mark.skipif(is_greater_or_equal_version("1.3.1", version), reason="requires Geospark version above 1.3.1")
     def test_st_is_ring(self):
         result_and_expected = [
             [self.calculate_st_is_ring("LINESTRING(0 0, 0 1, 1 0, 1 1, 0 0)"), False],

--- a/python/tests/utils/test_geo_spark_meta.py
+++ b/python/tests/utils/test_geo_spark_meta.py
@@ -1,15 +1,15 @@
-from geospark.core.jvm.config import compare_versions, GeoSparkMeta
+from geospark.core.jvm.config import is_greater_or_equal_version, GeoSparkMeta
 from tests.test_base import TestBase
 
 
 class TestGeoSparkMeta(TestBase):
 
     def test_meta(self):
-        assert not compare_versions("1.1.5", "1.2.0")
-        assert compare_versions("1.2.0", "1.1.5")
-        assert compare_versions("1.3.5", "1.2.0")
-        assert not compare_versions("", "1.2.0")
-        assert not compare_versions("1.3.5", "")
+        assert not is_greater_or_equal_version("1.1.5", "1.2.0")
+        assert is_greater_or_equal_version("1.2.0", "1.1.5")
+        assert is_greater_or_equal_version("1.3.5", "1.2.0")
+        assert not is_greater_or_equal_version("", "1.2.0")
+        assert not is_greater_or_equal_version("1.3.5", "")
         GeoSparkMeta.version = "1.2.0"
         assert GeoSparkMeta.version == "1.2.0"
         GeoSparkMeta.version = "1.3.0"

--- a/python/tests/utils/test_geo_spark_meta.py
+++ b/python/tests/utils/test_geo_spark_meta.py
@@ -5,7 +5,8 @@ from tests.test_base import TestBase
 class TestGeoSparkMeta(TestBase):
 
     def test_meta(self):
-        assert not compare_versions("1.2.0", "1.1.5")
+        assert not compare_versions("1.1.5", "1.2.0")
+        assert compare_versions("1.2.0", "1.1.5")
         assert compare_versions("1.3.5", "1.2.0")
         assert not compare_versions("", "1.2.0")
         assert not compare_versions("1.3.5", "")


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

No

## What changes were proposed in this PR?

The compare_versions function in python/geospark/core/jvm/config.py seems to have a bug.
I think this function is supposed to return True if the left side is equal or higher than the right, but it's broken in some cases.

```
In [1]: from geospark.core.jvm.config import compare_versions                                                                 

In [2]: compare_versions('1.2.3', '1.0.0')                                                                                    
Out[2]: True

In [3]: compare_versions('1.0.0', '1.3.2')                                                                                    
Out[3]: False

In [4]: compare_versions('1.3.2', '1.2.3')                                                                                    
Out[4]: False <- ??
```

This PR fixes the above bug.

## How was this patch tested?

I locally ran `cd python; pytest tests/utils/test_geo_spark_meta.py` and confirmed it succeeded.

## Did this PR include necessary documentation updates?

No