### PR TITLE
Fix CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,26 @@ before_install:
   - sudo pip3 install -U wheel
   - sudo pip3 install -U virtualenvwrapper
 install:
-- python3 -m pip install pipenv
-- wget https://archive.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz
-- tar -xzf spark-2.4.4-bin-hadoop2.7.tgz
-- rm spark-2.4.4-bin-hadoop2.7.tgz
+  - python3 -m pip install pipenv
+  - wget https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
+  - tar -xzf spark-3.0.0-bin-hadoop2.7.tgz
+  - rm spark-3.0.0-bin-hadoop2.7.tgz
 
 script:
   - (cd python;pipenv install --dev) 
-  - export SPARK_HOME=$PWD/spark-2.4.4-bin-hadoop2.7
+  - export SPARK_HOME=$PWD/spark-3.0.0-bin-hadoop2.7
   - export PYTHONPATH=$SPARK_HOME/python
   - mvn -q clean install
-  - find core/target/ -iregex "core\/target\/geospark-[0-9]\.[0-9]\.[0-9]\.jar" -exec cp {} $SPARK_HOME/jars \;
-  - find sql/target/ -iregex "sql\/target\/geospark-sql_[0-9]\.[0-9]-[0-9]\.[0-9]\.[0-9]\.jar" -exec cp {} $SPARK_HOME/jars \;
+  - find core/target/ -iregex "core\/target\/geospark-[0-9]\.[0-9]\.[0-9]\(-SNAPSHOT\)?\.jar" -exec cp {} $SPARK_HOME/jars \;
+  - find sql/target/ -iregex "sql\/target\/geospark-sql_[0-9]\.[0-9]-[0-9]\.[0-9]\.[0-9]\(-SNAPSHOT\)?\.jar" -exec cp {} $SPARK_HOME/jars \;
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=com.googlecode.efficient-java-matrix-library:core:0.26
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=net.java.dev.jsr-275:jsr-275:1.0-beta-2
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-epsg-extension:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-epsg-hsql:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-main:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-metadata:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-opengis:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-referencing:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.geotools:gt-shapefile:17.0
+  - mvn dependency:get -Ddest=${SPARK_HOME}/jars -Dartifact=org.hsqldb:hsqldb:2.3.0
   - (cd python;pipenv run pytest tests)

--- a/python/geospark/core/jvm/config.py
+++ b/python/geospark/core/jvm/config.py
@@ -65,8 +65,11 @@ class SparkJars:
         java_spark_conf = spark_conf._jconf
         try:
             used_jar_files = java_spark_conf.get("spark.jars")
+        except Exception as e:
+            logging.warning(f"Failed to get the value of spark.jars from SparkConf: {e}")
         finally:
             if not used_jar_files:
+                logging.info("Trying to get filenames from the $SPARK_HOME/jars directory")
                 used_jar_files = ",".join(os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars")))
         return used_jar_files
 

--- a/python/geospark/core/jvm/config.py
+++ b/python/geospark/core/jvm/config.py
@@ -65,8 +65,9 @@ class SparkJars:
         java_spark_conf = spark_conf._jconf
         try:
             used_jar_files = java_spark_conf.get("spark.jars")
-        except Exception as e:
-            used_jar_files = ",".join(os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars")))
+        finally:
+            if not used_jar_files:
+                used_jar_files = ",".join(os.listdir(os.path.join(os.environ["SPARK_HOME"], "jars")))
         return used_jar_files
 
     @property


### PR DESCRIPTION
## Is this PR related to a proposed Issue?

No

## What changes were proposed in this PR?

* Fix Travis configuration to use Spark 3.0.0, pick up the jar files
  which contains '-SNAPSHOT' in its version number, and download
  jar files that are not included in our distribution due to
  the license incompatibility but required to run all tests.

* Fix SparkJars.get_used_jars in geospark/core/jvm/config.py
  to search jar files from $SPARK_HOME/jars directly
  when SparkConf._jconf.get("spark.jars") returns empty string
  rather than raises Exception for some reason.

## How was this patch tested?

It's tested on CI and succeeded: https://travis-ci.org/github/sekikn/GeoSpark/builds/714655938

## Did this PR include necessary documentation updates?

No