### PR TITLE
Aggregate Functions rewrite for new Aggregator API

### DIFF
--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/Catalog.scala
@@ -16,8 +16,9 @@
  */
 package org.datasyslab.geosparksql.UDF
 
+import com.vividsolutions.jts.geom.Geometry
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
-import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
+import org.apache.spark.sql.expressions.{Aggregator}
 import org.apache.spark.sql.geosparksql.expressions._
 
 object Catalog {
@@ -76,7 +77,7 @@ object Catalog {
     ST_IsRing
   )
 
-  val aggregateExpressions:Seq[UserDefinedAggregateFunction] = Seq(
+  val aggregateExpressions:Seq[Aggregator[Geometry, Geometry, Geometry]] = Seq(
     new ST_Union_Aggr,
     new ST_Envelope_Aggr,
     new ST_Intersection_Aggr

--- a/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
+++ b/sql/src/main/scala/org/datasyslab/geosparksql/UDF/UdfRegistrator.scala
@@ -17,7 +17,7 @@
 package org.datasyslab.geosparksql.UDF
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.apache.spark.sql.{SQLContext, SparkSession, functions}
 
 object UdfRegistrator {
 
@@ -27,7 +27,7 @@ object UdfRegistrator {
 
   def registerAll(sparkSession: SparkSession): Unit = {
     Catalog.expressions.foreach(f=>sparkSession.sessionState.functionRegistry.createOrReplaceTempFunction(f.getClass.getSimpleName.dropRight(1),f))
-    Catalog.aggregateExpressions.foreach(f=>sparkSession.udf.register(f.getClass.getSimpleName,f))
+    Catalog.aggregateExpressions.foreach(f=> sparkSession.udf.register(f.getClass.getSimpleName,functions.udaf(f)))
   }
 
   def dropAll(sparkSession: SparkSession): Unit = {

--- a/sql/src/test/scala/org/datasyslab/geosparksql/TestBaseScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/TestBaseScala.scala
@@ -42,7 +42,7 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll{
     config("spark.kryo.registrator", classOf[GeoSparkKryoRegistrator].getName).
     master("local[*]").appName("geosparksqlScalaTest")
     .config("spark.sql.warehouse.dir", warehouseLocation)
-    //.enableHiveSupport()
+    .enableHiveSupport()
     .getOrCreate()
 
   import sparkSession.implicits._

--- a/sql/src/test/scala/org/datasyslab/geosparksql/TestBaseScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/TestBaseScala.scala
@@ -42,7 +42,8 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll{
     config("spark.kryo.registrator", classOf[GeoSparkKryoRegistrator].getName).
     master("local[*]").appName("geosparksqlScalaTest")
     .config("spark.sql.warehouse.dir", warehouseLocation)
-    .enableHiveSupport().getOrCreate()
+    //.enableHiveSupport()
+    .getOrCreate()
 
   import sparkSession.implicits._
 

--- a/sql/src/test/scala/org/datasyslab/geosparksql/aggregateFunctionTestScala.scala
+++ b/sql/src/test/scala/org/datasyslab/geosparksql/aggregateFunctionTestScala.scala
@@ -27,6 +27,9 @@
 package org.datasyslab.geosparksql
 
 import com.vividsolutions.jts.geom.{Coordinate, Geometry, GeometryFactory}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.expressions.UserDefinedAggregator
+import org.apache.spark.sql.functions
 
 class aggregateFunctionTestScala extends TestBaseScala {
 
@@ -60,37 +63,37 @@ class aggregateFunctionTestScala extends TestBaseScala {
       var union = sparkSession.sql("select ST_Union_Aggr(polygondf.polygonshape) from polygondf")
       assert(union.take(1)(0).get(0).asInstanceOf[Geometry].getArea == 10100)
     }
-  }
 
-  it("Passed ST_Intersection_aggr") {
+    it("Passed ST_Intersection_aggr") {
 
-    val twoPolygonsAsWktDf = sparkSession.read.textFile(intersectionPolygonInputLocation).toDF("polygon_wkt")
-    twoPolygonsAsWktDf.createOrReplaceTempView("two_polygons_wkt")
-    twoPolygonsAsWktDf.show()
+      val twoPolygonsAsWktDf = sparkSession.read.textFile(intersectionPolygonInputLocation).toDF("polygon_wkt")
+      twoPolygonsAsWktDf.createOrReplaceTempView("two_polygons_wkt")
+      twoPolygonsAsWktDf.show()
 
-    sparkSession
-      .sql("select ST_GeomFromWKT(polygon_wkt) as polygon from two_polygons_wkt")
-      .createOrReplaceTempView("two_polygons")
+      sparkSession
+        .sql("select ST_GeomFromWKT(polygon_wkt) as polygon from two_polygons_wkt")
+        .createOrReplaceTempView("two_polygons")
 
-    val intersectionDF = sparkSession.sql("select ST_Intersection_Aggr(polygon) from two_polygons")
-    intersectionDF.show(false)
+      val intersectionDF = sparkSession.sql("select ST_Intersection_Aggr(polygon) from two_polygons")
+      intersectionDF.show(false)
 
-    assertResult(0.0034700160226227607)(intersectionDF.take(1)(0).get(0).asInstanceOf[Geometry].getArea)
-  }
+      assertResult(0.0034700160226227607)(intersectionDF.take(1)(0).get(0).asInstanceOf[Geometry].getArea)
+    }
 
-  it("Passed ST_Intersection_aggr no intersection gives empty polygon") {
+    it("Passed ST_Intersection_aggr no intersection gives empty polygon") {
 
-    val twoPolygonsAsWktDf = sparkSession.read.textFile(intersectionPolygonNoIntersectionInputLocation).toDF("polygon_wkt")
-    twoPolygonsAsWktDf.createOrReplaceTempView("two_polygons_no_intersection_wkt")
-    twoPolygonsAsWktDf.show()
+      val twoPolygonsAsWktDf = sparkSession.read.textFile(intersectionPolygonNoIntersectionInputLocation).toDF("polygon_wkt")
+      twoPolygonsAsWktDf.createOrReplaceTempView("two_polygons_no_intersection_wkt")
+      twoPolygonsAsWktDf.show()
 
-    sparkSession
-      .sql("select ST_GeomFromWKT(polygon_wkt) as polygon from two_polygons_no_intersection_wkt")
-      .createOrReplaceTempView("two_polygons_no_intersection")
+      sparkSession
+        .sql("select ST_GeomFromWKT(polygon_wkt) as polygon from two_polygons_no_intersection_wkt")
+        .createOrReplaceTempView("two_polygons_no_intersection")
 
-    val intersectionDF = sparkSession.sql("select ST_Intersection_Aggr(polygon) from two_polygons_no_intersection")
-    intersectionDF.show(false)
+      val intersectionDF = sparkSession.sql("select ST_Intersection_Aggr(polygon) from two_polygons_no_intersection")
+      intersectionDF.show(false)
 
-    assertResult(0.0)(intersectionDF.take(1)(0).get(0).asInstanceOf[Geometry].getArea)
+      assertResult(0.0)(intersectionDF.take(1)(0).get(0).asInstanceOf[Geometry].getArea)
+    }
   }
 }


### PR DESCRIPTION
## Is this PR related to a proposed Issue?
No

## What changes were proposed in this PR?
User Defined Aggregate Functions API is depreciated in Spark 3.0.
(https://github.com/apache/spark/pull/25024)
So I rewrite user defined aggregate functions.

## How was this patch tested?
yes. add to test.

## Did this PR include necessary documentation updates?
no(function is not changed)